### PR TITLE
Rate Limiter Implementation

### DIFF
--- a/CodeMap.dgml
+++ b/CodeMap.dgml
@@ -1,0 +1,467 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DirectedGraph DataVirtualized="True" Layout="Sugiyama" ZoomLevel="1" xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+  <Nodes>
+    <Node Id="(@1 @11 @34 Member=(Name=Delete OverloadingParameters=[(@38 Namespace=System Type=Int32)]))" Category="CodeSchema_Method" Bounds="-85.3699407557001,-171.226627204491,70.2166666666667,25.96" CodeSchemaProperty_IsPublic="True" DelayedCrossGroupLinksState="Fetched" Label="Delete" />
+    <Node Id="(@1 @11 @34 Member=(Name=Get OverloadingParameters=[(@38 Namespace=System Type=Int32)]))" Category="CodeSchema_Method" Bounds="-5.68326876354389,-227.186649352965,54.5766666666667,25.96" CodeSchemaProperty_IsPublic="True" DelayedCrossGroupLinksState="Fetched" Label="Get" />
+    <Node Id="(@1 @11 @34 Member=(Name=Post OverloadingParameters=[(@38 Namespace=System Type=String)]))" Category="CodeSchema_Method" Bounds="-173.836592672204,-171.226627204491,58.4666666666667,25.96" CodeSchemaProperty_IsPublic="True" DelayedCrossGroupLinksState="Fetched" Label="Post" />
+    <Node Id="(@1 @11 @34 Member=(Name=Put OverloadingParameters=[(@38 Namespace=System Type=Int32),(@38 Namespace=System Type=String)]))" Category="CodeSchema_Method" Bounds="-173.836592685645,-227.186651814471,53.5766666666667,25.96" CodeSchemaProperty_IsPublic="True" DelayedCrossGroupLinksState="Fetched" Label="Put" />
+    <Node Id="(@1 @11 @34 Member=.ctor)" Category="CodeSchema_Method" Bounds="-173.836593536869,-115.266628394834,122.53,25.96" CodeSchemaProperty_IsConstructor="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsSpecialName="True" DelayedCrossGroupLinksState="Fetched" Label="ValuesController" />
+    <Node Id="(@1 @11 @34 Member=Get)" Category="CodeSchema_Method" Bounds="-90.2599396808641,-227.186649352965,54.5766666666667,25.96" CodeSchemaProperty_IsPublic="True" DelayedCrossGroupLinksState="Fetched" Label="Get" />
+    <Node Id="(@1 @13 @27 Member=.ctor)" Category="CodeSchema_Method" Bounds="-410.138239356978,-115.266629215335,125.333333333333,25.96" CodeSchemaProperty_IsConstructor="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsSpecialName="True" DelayedCrossGroupLinksState="Fetched" Label="RequestValidator" />
+    <Node Id="(@1 @9 @32 Member=(Name=.ctor OverloadingParameters=[(@38 Namespace=System Type=Boolean),(@38 Namespace=System Type=Boolean)]))" Category="CodeSchema_Method" Bounds="-437.417353831465,118.340857621513,174.643333333333,25.96" CodeSchemaProperty_IsConstructor="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsSpecialName="True" DelayedCrossGroupLinksState="Fetched" Label="ValidateRateLimitAttribute" />
+    <Node Id="(@1 Namespace=::)" Category="CodeSchema_Namespace" Bounds="118.893393530804,-137.205092885187,62.2,25.007448" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="0" Group="Collapsed" Label="::" />
+    <Node Id="(@5 Namespace=RateLimiter.Tests)" Category="CodeSchema_Namespace" Bounds="6.37091136146948,-422.292910350193,145.19,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="RateLimiter‎.Tests" />
+    <Node Id="@10" Category="CodeSchema_Namespace" Bounds="-477.417356042462,-17.643850038744,415.891477693981,256.9206" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Label="RateLimiter‎.Api‎.Attributes" />
+    <Node Id="@12" Category="CodeSchema_Namespace" Bounds="-213.836604004563,-307.211524848033,302.730005172094,257.8806" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Label="RateLimiter‎.Api‎.Controllers" />
+    <Node Id="@14" Category="CodeSchema_Namespace" Bounds="-450.138257328269,-307.211549123217,205.333334350586,257.8806" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Label="RateLimiter‎.Api‎.Validators" />
+    <Node Id="@15" Category="CodeSchema_Namespace" Bounds="-49.4217080931277,560.232250702199,151.686666666667,85.0002" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Label="RateLimiter‎.Data" UseManualLocation="True" />
+    <Node Id="@16" Category="CodeSchema_Namespace" Bounds="-6.19130761125521,845.148354580306,154.623333333333,85" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Label="RateLimiter‎.Enums" UseManualLocation="True" />
+    <Node Id="@18" Category="CodeSchema_Namespace" Bounds="-110.584591230901,675.167995303978,397.373333333333,140.0003" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="3" Group="Expanded" Label="RateLimiter‎.Models" UseManualLocation="True" />
+    <Node Id="@2" Category="CodeSchema_Assembly" AssemblyTimestamp="01/29/2020 07:03:52" Bounds="-497.417356042462,-347.2263278757,1129.53074957327,606.503177836956" CodeSchemaProperty_StrongName="RateLimiter.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="5" FilePath="$(f1a9162d-6b41-4afb-afaa-eea62d2040de.OutputPath)" Group="Expanded" Label="RateLimiter.Api.dll" UseManualLocation="True">
+      <Category Ref="CodeMap_WebProject" />
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@20" Category="CodeSchema_Namespace" Bounds="-29.4274104552982,329.271747322198,201.183333333333,200.9605" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="2" Group="Expanded" Label="RateLimiter‎.Utilities" UseManualLocation="True" />
+    <Node Id="@21" Category="CodeSchema_Class" Bounds="130.235408769099,770.168195303978,108.506666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="BaseRule" />
+    <Node Id="@22" Category="CodeSchema_Class" Bounds="459.394879609587,-212.292405573526,132.69,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="BundleConfig" />
+    <Node Id="@23" Category="CodeSchema_Class" Bounds="306.654879609588,-212.292405573526,122.17,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="FilterConfig" />
+    <Node Id="@24" Category="CodeSchema_Class" Bounds="102.188742102432,715.168115303958,164.6,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="FrequencyLimitRule" />
+    <Node Id="@25" Category="CodeSchema_Class" Bounds="4.26258908103802,485.243772918825,133.803333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="HistoryHelper" />
+    <Node Id="@26" Category="CodeSchema_Class" Bounds="-9.42741045529818,369.271847322198,161.183333333333,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Label="RateLimitSimulator" UseManualLocation="True" />
+    <Node Id="@28" Category="CodeSchema_Class" Bounds="-430.138257328269,-267.211449123217,165.333334350586,197.8804" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="3" Group="Expanded" Label="RequestValidator" />
+    <Node Id="@29" Category="CodeSchema_Enum" Bounds="16.1170257220781,885.148354580306,110.006666666667,25" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="RuleTypes" />
+    <Node Id="@30" Category="CodeSchema_Class" Bounds="-29.4217080931277,600.232350702199,111.686666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="SeedData" />
+    <Node Id="@31" Category="CodeSchema_Class" Bounds="-90.5845912309011,715.168115303958,162.146666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="TimeSpanLimitRule" />
+    <Node Id="@33" Category="CodeSchema_Class" Bounds="-457.417356042462,22.3562499612559,375.891477693981,196.9204" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="4" Group="Expanded" Label="ValidateRateLimitAttribute" />
+    <Node Id="@35" Category="CodeSchema_Class" Bounds="-193.836604004563,-267.211424848033,262.730005172094,197.8804" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="6" Group="Expanded" Label="ValuesController" />
+    <Node Id="@36" Category="CodeSchema_Class" Bounds="286.303212942921,-267.292505573526,162.873333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="WebApiApplication" />
+    <Node Id="@37" Category="CodeSchema_Class" Bounds="138.864879609587,-212.292405573526,137.75,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="WebApiConfig" />
+    <Node Id="@39" Category="CodeSchema_Method" Bounds="-410.13824037423,-171.226628024992,101.716666666667,25.96" CodeSchemaProperty_IsPrivate="True" CodeSchemaProperty_IsStatic="True" DelayedCrossGroupLinksState="Fetched" Label="GetAttribute" />
+    <Node Id="@4" Category="CodeSchema_Assembly" Bounds="-130.518574473183,289.21429626343,437.373333333333,660.96168000002" CodeSchemaProperty_StrongName="RateLimiter, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="4" FilePath="$(36f4bdc6-d3da-403a-8db7-0c79f94b938f.OutputPath)" Group="Expanded" Label="RateLimiter.dll" UseManualLocation="True" />
+    <Node Id="@40" Category="CodeSchema_Method" Bounds="30.2825940552795,409.283743370331,81.7633333333333,25.96" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsStatic="True" DelayedCrossGroupLinksState="Fetched" Label="Simulate" />
+    <Node Id="@42" Category="CodeSchema_Method" Bounds="-437.417327680952,62.3808698691374,154.633333333333,25.96" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="OnAuthorizationAsync" />
+    <Node Id="@43" Category="CodeSchema_Property" Bounds="-264.358273135862,174.300883080569,162.832394787382,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ApplyQuantityRules" />
+    <Node Id="@44" Category="CodeSchema_Property" Bounds="-437.41733458991,174.300883080569,143.059061454048,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ApplyTimeRules" />
+    <Node Id="@45" Category="CodeSchema_Method" Bounds="-398.284907040897,-227.186652634973,78.01,25.96" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsStatic="True" DelayedCrossGroupLinksState="Fetched" Label="Validate" />
+    <Node Id="@6" Category="CodeSchema_Assembly" Bounds="-13.6102207602131,-462.226531302297,185.19,85.0002" CodeSchemaProperty_StrongName="RateLimiter.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" FilePath="$(c4f9249b-010e-46be-94b8-dd20d82f1e60.OutputPath)" Group="Expanded" Label="RateLimiter.Tests.dll" UseManualLocation="True" />
+    <Node Id="@8" Category="CodeSchema_Namespace" Bounds="118.893393530804,-307.2262278757,493.22,140.0003" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="4" Group="Expanded" Label="RateLimiter‎.Api" />
+  </Nodes>
+  <Links>
+    <Link Source="@10" Target="@33" Category="Contains" FetchingParent="@10" />
+    <Link Source="@12" Target="@35" Category="Contains" FetchingParent="@12" />
+    <Link Source="@14" Target="@28" Category="Contains" FetchingParent="@14" />
+    <Link Source="@15" Target="@30" Category="Contains" FetchingParent="@15" />
+    <Link Source="@16" Target="@29" Category="Contains" FetchingParent="@16" />
+    <Link Source="@18" Target="@21" Category="Contains" FetchingParent="@18" />
+    <Link Source="@18" Target="@24" Category="Contains" FetchingParent="@18" />
+    <Link Source="@18" Target="@31" Category="Contains" FetchingParent="@18" />
+    <Link Source="@2" Target="(@1 Namespace=::)" Category="Contains" FetchingParent="@2" />
+    <Link Source="@2" Target="@10" Category="Contains" FetchingParent="@2" />
+    <Link Source="@2" Target="@12" Category="Contains" FetchingParent="@2" />
+    <Link Source="@2" Target="@14" Category="Contains" FetchingParent="@2" />
+    <Link Source="@2" Target="@4" Category="CodeMap_ProjectReference" />
+    <Link Source="@2" Target="@8" Category="Contains" FetchingParent="@2" />
+    <Link Source="@20" Target="@25" Category="Contains" FetchingParent="@20" />
+    <Link Source="@20" Target="@26" Category="Contains" FetchingParent="@20" />
+    <Link Source="@21" Target="@29" Category="References" IsSourceVirtualized="True" Weight="2" />
+    <Link Source="@24" Target="@21" Category="InheritsFrom" Bounds="184.394561767578,740.196594238281,0,21.0000610351563" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@26" Target="@40" Category="Contains" FetchingParent="@26" />
+    <Link Source="@28" Target="(@1 @13 @27 Member=.ctor)" Category="Contains" FetchingParent="@28" />
+    <Link Source="@28" Target="@39" Category="Contains" FetchingParent="@28" />
+    <Link Source="@28" Target="@45" Category="Contains" FetchingParent="@28" />
+    <Link Source="@30" Target="@24" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@30" Target="@31" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@31" Target="@21" Category="InheritsFrom" Bounds="34.4854698181152,740.196594238281,97.1594276428223,27.5452270507813" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@33" Target="(@1 @9 @32 Member=(Name=.ctor OverloadingParameters=[(@38 Namespace=System Type=Boolean),(@38 Namespace=System Type=Boolean)]))" Category="Contains" FetchingParent="@33" />
+    <Link Source="@33" Target="@42" Category="Contains" FetchingParent="@33" />
+    <Link Source="@33" Target="@43" Category="Contains" FetchingParent="@33" />
+    <Link Source="@33" Target="@44" Category="Contains" FetchingParent="@33" />
+    <Link Source="@35" Target="(@1 @11 @34 Member=(Name=Delete OverloadingParameters=[(@38 Namespace=System Type=Int32)]))" Category="Contains" FetchingParent="@35" />
+    <Link Source="@35" Target="(@1 @11 @34 Member=(Name=Get OverloadingParameters=[(@38 Namespace=System Type=Int32)]))" Category="Contains" FetchingParent="@35" />
+    <Link Source="@35" Target="(@1 @11 @34 Member=(Name=Post OverloadingParameters=[(@38 Namespace=System Type=String)]))" Category="Contains" FetchingParent="@35" />
+    <Link Source="@35" Target="(@1 @11 @34 Member=(Name=Put OverloadingParameters=[(@38 Namespace=System Type=Int32),(@38 Namespace=System Type=String)]))" Category="Contains" FetchingParent="@35" />
+    <Link Source="@35" Target="(@1 @11 @34 Member=.ctor)" Category="Contains" FetchingParent="@35" />
+    <Link Source="@35" Target="(@1 @11 @34 Member=Get)" Category="Contains" FetchingParent="@35" />
+    <Link Source="@35" Target="@33" Category="CodeSchema_AttributeUse" Bounds="-193.758449825877,-69.4152327905058,60.4126196887689,84.3697701636039" Weight="1" />
+    <Link Source="@36" Target="@22" Category="CodeSchema_Calls" Bounds="403.689147949219,-242.070892333984,77.6820678710938,27.0412292480469" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@36" Target="@23" Category="CodeSchema_Calls" Bounds="367.780059814453,-242.070892333984,0,21" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@36" Target="@37" Category="CodeSchema_FunctionPointer" Bounds="252.654861450195,-242.070892333984,78.7615509033203,27.0742797851563" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@39" Target="@33" Category="CodeSchema_ReturnTypeLink" Bounds="-355.131174132108,-145.349974662228,51.1872742960998,159.054741492668" Weight="1" />
+    <Link Source="@4" Target="@15" Category="Contains" FetchingParent="@4" />
+    <Link Source="@4" Target="@16" Category="Contains" FetchingParent="@4" />
+    <Link Source="@4" Target="@18" Category="Contains" FetchingParent="@4" />
+    <Link Source="@4" Target="@20" Category="Contains" FetchingParent="@4" />
+    <Link Source="@40" Target="@24" Category="CodeSchema_Calls" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@40" Target="@25" Category="CodeSchema_Calls" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@40" Target="@29" Category="References" Weight="1" />
+    <Link Source="@40" Target="@30" Category="CodeSchema_FieldRead" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@40" Target="@31" Category="CodeSchema_Calls" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@42" Target="@45" Category="CodeSchema_Calls" Weight="1" />
+    <Link Source="@45" Target="@39" Category="CodeSchema_Calls" Bounds="-359.268280029297,-201.110885620117,0,21" Weight="1" />
+    <Link Source="@45" Target="@40" Category="CodeSchema_Calls" Weight="2" />
+    <Link Source="@45" Target="@43" Category="CodeSchema_Calls" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@45" Target="@44" Category="CodeSchema_Calls" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@6" Target="(@5 Namespace=RateLimiter.Tests)" Category="Contains" FetchingParent="@6" />
+    <Link Source="@6" Target="@4" Category="CodeMap_ProjectReference" Bounds="171.565200805664,-409.539001464844,470.653427124023,886.140197753906" />
+    <Link Source="@8" Target="@22" Category="Contains" FetchingParent="@8" />
+    <Link Source="@8" Target="@23" Category="Contains" FetchingParent="@8" />
+    <Link Source="@8" Target="@36" Category="Contains" FetchingParent="@8" />
+    <Link Source="@8" Target="@37" Category="Contains" FetchingParent="@8" />
+  </Links>
+  <Categories>
+    <Category Id="CodeMap_ProjectReference" Label="Project Reference" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Referenced By" OutgoingActionLabel="References" />
+    <Category Id="CodeMap_WebProject" Label="Web Project" CanBeDataDriven="True" IsProviderRoot="False" NavigationActionLabel="Web Projects" />
+    <Category Id="CodeSchema_Assembly" Label="Assembly" BasedOn="File" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="CodeSchema_Assembly" NavigationActionLabel="Assemblies" />
+    <Category Id="CodeSchema_AttributeUse" Label="Uses Attribute" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Used by" OutgoingActionLabel="Uses Attribute" />
+    <Category Id="CodeSchema_Calls" Label="Calls" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Called By" OutgoingActionLabel="Calls" />
+    <Category Id="CodeSchema_Class" Label="Class" BasedOn="CodeSchema_Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Class" NavigationActionLabel="Classes" />
+    <Category Id="CodeSchema_Enum" Label="Enum" BasedOn="CodeSchema_Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Enum" NavigationActionLabel="Enums" />
+    <Category Id="CodeSchema_FieldRead" Label="Field Read" BasedOn="CodeSchema_FieldReference" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Read By" OutgoingActionLabel="Reads Fields" />
+    <Category Id="CodeSchema_FieldReference" Label="Field Reference" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Referenced By" OutgoingActionLabel="References Fields" />
+    <Category Id="CodeSchema_FunctionPointer" Label="Function Pointer" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Function Pointers" OutgoingActionLabel="Function Pointers" />
+    <Category Id="CodeSchema_Member" Label="Member" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="CodeSchema_Field" NavigationActionLabel="Members" />
+    <Category Id="CodeSchema_Method" Label="Method" BasedOn="CodeSchema_Member" CanBeDataDriven="True" DefaultAction="Link:Forward:CodeSchema_Calls" Icon="CodeSchema_Method" NavigationActionLabel="Methods" />
+    <Category Id="CodeSchema_Namespace" Label="Namespace" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Type" Icon="CodeSchema_Namespace" NavigationActionLabel="Namespaces" />
+    <Category Id="CodeSchema_Property" Label="Property" BasedOn="CodeSchema_Member" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="CodeSchema_Property" NavigationActionLabel="Properties" />
+    <Category Id="CodeSchema_ReturnTypeLink" Label="Return" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Return types" OutgoingActionLabel="Return types" />
+    <Category Id="CodeSchema_Type" Label="Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Class" NavigationActionLabel="Types" />
+    <Category Id="Contains" Label="Contains" Description="Whether the source of the link contains the target object" CanBeDataDriven="False" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Contained By" IsContainment="True" OutgoingActionLabel="Contains" />
+    <Category Id="File" Label="File" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="File" NavigationActionLabel="Files" />
+    <Category Id="FileSystem.Category.FileOfType.dll" BasedOn="CodeSchema_Assembly" CanBeDataDriven="True" IsProviderRoot="False" />
+    <Category Id="InheritsFrom" Label="Inherits From" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Inherited By" OutgoingActionLabel="Inherits From" />
+    <Category Id="References" Label="References" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Referenced By" OutgoingActionLabel="References" />
+  </Categories>
+  <Properties>
+    <Property Id="AssemblyTimestamp" DataType="System.DateTime" />
+    <Property Id="Bounds" DataType="System.Windows.Rect" />
+    <Property Id="CanBeDataDriven" Label="CanBeDataDriven" Description="CanBeDataDriven" DataType="System.Boolean" />
+    <Property Id="CanLinkedNodesBeDataDriven" Label="CanLinkedNodesBeDataDriven" Description="CanLinkedNodesBeDataDriven" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsAbstract" Label="Is Abstract" Description="Flag to indicate member is 'Abstract' does not provide a full implementation" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsConstructor" Label="Is Constructor" Description="Flag to indicate the method is a constructor" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsFinal" Label="Is Final" Description="Flag to indicate the member is 'Final' and cannot be derived from" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsPrivate" Label="Is Private" Description="Flag to indicate the scope is Private" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsPublic" Label="Is Public" Description="Flag to indicate the scope is Public" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsSpecialName" Label="Is Special Name" Description="Flag to indicate the method is treated in a special way by some compilers" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsStatic" Label="Is Static" Description="Flag to indicate the member is a static member" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsVirtual" Label="Is Virtual" Description="Flag to indicate the method can be overridden" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_StrongName" Label="StrongName" Description="StrongName" DataType="System.String" />
+    <Property Id="DataVirtualized" Label="Data Virtualized" Description="If true, the graph can contain nodes and links that represent data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="DefaultAction" Label="DefaultAction" Description="DefaultAction" DataType="System.String" />
+    <Property Id="DelayedChildNodesState" Label="Delayed Child Nodes State" Description="Unspecified if the delayed child nodes state is not specified. NotFetched if the group contains child nodes that are not fetched into the graph yet. Fetched if the group has all its delayed child nodes already fetched." DataType="Microsoft.VisualStudio.GraphModel.DelayedDataState" />
+    <Property Id="DelayedCrossGroupLinksState" Label="Delayed Cross-Group Links State" Description="Unspecified if the delayed cross-group links state is not specified. NotFetched if delayed cross-group links on this node are not fetched into the graph yet. Fetched if all delayed cross-group links have already fetched." DataType="Microsoft.VisualStudio.GraphModel.DelayedDataState" />
+    <Property Id="Expression" DataType="System.String" />
+    <Property Id="FetchedChildrenCount" DataType="System.Int32" />
+    <Property Id="FetchingParent" DataType="Microsoft.VisualStudio.GraphModel.GraphNodeId" />
+    <Property Id="FilePath" Label="File Path" Description="File Path" DataType="System.String" />
+    <Property Id="Group" Label="Group" Description="Display the node as a group" DataType="Microsoft.VisualStudio.GraphModel.GraphGroupStyle" />
+    <Property Id="GroupLabel" DataType="System.String" />
+    <Property Id="Icon" Label="Icon" Description="Icon" DataType="System.String" />
+    <Property Id="IncomingActionLabel" Label="IncomingActionLabel" Description="IncomingActionLabel" DataType="System.String" />
+    <Property Id="IsContainment" DataType="System.Boolean" />
+    <Property Id="IsEnabled" DataType="System.Boolean" />
+    <Property Id="IsProviderRoot" Label="IsProviderRoot" Description="IsProviderRoot" DataType="System.Boolean" />
+    <Property Id="IsSourceVirtualized" Label="Link Source Virtualized" Description="If true, the link source end contains data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="IsTargetVirtualized" Label="Link Target Virtualized" Description="If true, the link target end contains data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="Label" Label="Label" Description="Displayable label of an Annotatable object" DataType="System.String" />
+    <Property Id="Layout" DataType="System.String" />
+    <Property Id="NavigationActionLabel" Label="NavigationActionLabel" Description="NavigationActionLabel" DataType="System.String" />
+    <Property Id="OutgoingActionLabel" Label="OutgoingActionLabel" Description="OutgoingActionLabel" DataType="System.String" />
+    <Property Id="TargetType" DataType="System.Type" />
+    <Property Id="UseManualLocation" DataType="System.Boolean" />
+    <Property Id="Value" DataType="System.String" />
+    <Property Id="ValueLabel" DataType="System.String" />
+    <Property Id="Visibility" Label="Visibility" Description="Defines whether a node in the graph is visible or not" DataType="System.Windows.Visibility" />
+    <Property Id="Weight" Label="Weight" Description="Weight" DataType="System.Double" />
+    <Property Id="ZoomLevel" DataType="System.String" />
+  </Properties>
+  <QualifiedNames>
+    <Name Id="Assembly" Label="Assembly" ValueType="Uri" />
+    <Name Id="Member" Label="Member" ValueType="System.Object" />
+    <Name Id="Name" Label="Name" ValueType="System.String" />
+    <Name Id="Namespace" Label="Namespace" ValueType="System.String" />
+    <Name Id="OverloadingParameters" Label="Parameter" ValueType="Microsoft.VisualStudio.GraphModel.GraphNodeIdCollection" Formatter="NameValueNoEscape" />
+    <Name Id="Type" Label="Type" ValueType="System.Object" />
+  </QualifiedNames>
+  <IdentifierAliases>
+    <Alias n="1" Uri="Assembly=$(f1a9162d-6b41-4afb-afaa-eea62d2040de.OutputPathUri)" />
+    <Alias n="2" Id="(@1)" />
+    <Alias n="3" Uri="Assembly=$(36f4bdc6-d3da-403a-8db7-0c79f94b938f.OutputPathUri)" />
+    <Alias n="4" Id="(@3)" />
+    <Alias n="5" Uri="Assembly=$(c4f9249b-010e-46be-94b8-dd20d82f1e60.OutputPathUri)" />
+    <Alias n="6" Id="(@5)" />
+    <Alias n="7" Id="Namespace=RateLimiter.Api" />
+    <Alias n="8" Id="(@1 @7)" />
+    <Alias n="9" Id="Namespace=RateLimiter.Api.Attributes" />
+    <Alias n="10" Id="(@1 @9)" />
+    <Alias n="11" Id="Namespace=RateLimiter.Api.Controllers" />
+    <Alias n="12" Id="(@1 @11)" />
+    <Alias n="13" Id="Namespace=RateLimiter.Api.Validators" />
+    <Alias n="14" Id="(@1 @13)" />
+    <Alias n="15" Id="(@3 Namespace=RateLimiter.Data)" />
+    <Alias n="16" Id="(@3 Namespace=RateLimiter.Enums)" />
+    <Alias n="17" Id="Namespace=RateLimiter.Models" />
+    <Alias n="18" Id="(@3 @17)" />
+    <Alias n="19" Id="Namespace=RateLimiter.Utilities" />
+    <Alias n="20" Id="(@3 @19)" />
+    <Alias n="21" Id="(@3 @17 Type=BaseRule)" />
+    <Alias n="22" Id="(@1 @7 Type=BundleConfig)" />
+    <Alias n="23" Id="(@1 @7 Type=FilterConfig)" />
+    <Alias n="24" Id="(@3 @17 Type=FrequencyLimitRule)" />
+    <Alias n="25" Id="(@3 @19 Type=HistoryHelper)" />
+    <Alias n="26" Id="(@3 @19 Type=RateLimitSimulator)" />
+    <Alias n="27" Id="Type=RequestValidator" />
+    <Alias n="28" Id="(@1 @13 @27)" />
+    <Alias n="29" Id="(@3 Namespace=RateLimiter.Enums Type=RuleTypes)" />
+    <Alias n="30" Id="(@3 Namespace=RateLimiter.Data Type=SeedData)" />
+    <Alias n="31" Id="(@3 @17 Type=TimeSpanLimitRule)" />
+    <Alias n="32" Id="Type=ValidateRateLimitAttribute" />
+    <Alias n="33" Id="(@1 @9 @32)" />
+    <Alias n="34" Id="Type=ValuesController" />
+    <Alias n="35" Id="(@1 @11 @34)" />
+    <Alias n="36" Id="(@1 @7 Type=WebApiApplication)" />
+    <Alias n="37" Id="(@1 @7 Type=WebApiConfig)" />
+    <Alias n="38" Uri="Assembly=$(FxReferenceAssembliesUri)/.NETFramework/v4.7.2/mscorlib.dll" />
+    <Alias n="39" Id="(@1 @13 @27 Member=(Name=GetAttribute OverloadingParameters=[(@38 Namespace=System.Reflection Type=MemberInfo)]))" />
+    <Alias n="40" Id="(@3 @19 Type=RateLimitSimulator Member=(Name=Simulate OverloadingParameters=[@29]))" />
+    <Alias n="41" Uri="Assembly=$(VsSolutionUri)/packages/Microsoft.AspNet.WebApi.Core.5.2.7/lib/net45/System.Web.Http.dll" />
+    <Alias n="42" Id="(@1 @9 @32 Member=(Name=OnAuthorizationAsync OverloadingParameters=[(@41 Namespace=System.Web.Http.Controllers Type=HttpActionContext),(@38 Namespace=System.Threading Type=CancellationToken)]))" />
+    <Alias n="43" Id="(@1 @9 @32 Member=ApplyQuantityRules)" />
+    <Alias n="44" Id="(@1 @9 @32 Member=ApplyTimeRules)" />
+    <Alias n="45" Id="(@1 @13 @27 Member=Validate)" />
+  </IdentifierAliases>
+  <Styles>
+    <Style TargetType="Node" GroupLabel="Results" ValueLabel="True">
+      <Condition Expression="HasCategory('QueryResult')" />
+      <Setter Property="Background" Value="#FFBCFFBE" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Test Project" ValueLabel="Test Project">
+      <Condition Expression="HasCategory('CodeMap_TestProject')" />
+      <Setter Property="Icon" Value="CodeMap_TestProject" />
+      <Setter Property="Background" Value="#FF307A69" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Web Project" ValueLabel="Web Project">
+      <Condition Expression="HasCategory('CodeMap_WebProject')" />
+      <Setter Property="Icon" Value="CodeMap_WebProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Windows Store Project" ValueLabel="Windows Store Project">
+      <Condition Expression="HasCategory('CodeMap_WindowsStoreProject')" />
+      <Setter Property="Icon" Value="CodeMap_WindowsStoreProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Phone Project" ValueLabel="Phone Project">
+      <Condition Expression="HasCategory('CodeMap_PhoneProject')" />
+      <Setter Property="Icon" Value="CodeMap_PhoneProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Portable Library" ValueLabel="Portable Library">
+      <Condition Expression="HasCategory('CodeMap_PortableLibraryProject')" />
+      <Setter Property="Icon" Value="CodeMap_PortableLibraryProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="WPF Project" ValueLabel="WPF Project">
+      <Condition Expression="HasCategory('CodeMap_WpfProject')" />
+      <Setter Property="Icon" Value="CodeMap_WpfProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="VSIX Project" ValueLabel="VSIX Project">
+      <Condition Expression="HasCategory('CodeMap_VsixProject')" />
+      <Setter Property="Icon" Value="CodeMap_VsixProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Modeling Project" ValueLabel="Modeling Project">
+      <Condition Expression="HasCategory('CodeMap_ModelingProject')" />
+      <Setter Property="Icon" Value="CodeMap_ModelingProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Assembly" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Assembly')" />
+      <Setter Property="Background" Value="#FF094167" />
+      <Setter Property="Stroke" Value="#FF094167" />
+      <Setter Property="Icon" Value="CodeSchema_Assembly" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Namespace" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Namespace')" />
+      <Setter Property="Background" Value="#FF0E619A" />
+      <Setter Property="Stroke" Value="#FF0E619A" />
+      <Setter Property="Icon" Value="CodeSchema_Namespace" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Interface" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Interface')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Interface" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Struct" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Struct')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Struct" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Enumeration" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Enum')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Enum" />
+      <Setter Property="LayoutSettings" Value="List" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Delegate" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Delegate')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Delegate" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Class" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Type')" />
+      <Setter Property="Background" Value="#FF0E70C0" />
+      <Setter Property="Stroke" Value="#FF0E70C0" />
+      <Setter Property="Icon" Value="CodeSchema_Class" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Property" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Property')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Property" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Method" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Method') Or HasCategory('CodeSchema_CallStackUnresolvedMethod')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Method" />
+      <Setter Property="LayoutSettings" Value="List" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Event" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Event')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Event" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Field" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Field')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Field" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Out Parameter" ValueLabel="Has category">
+      <Condition Expression="CodeSchemaProperty_IsOut = 'True'" />
+      <Setter Property="Icon" Value="CodeSchema_OutParameter" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Parameter" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Parameter')" />
+      <Setter Property="Icon" Value="CodeSchema_Parameter" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Local Variable" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_LocalExpression')" />
+      <Setter Property="Icon" Value="CodeSchema_LocalExpression" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Externals" ValueLabel="Has category">
+      <Condition Expression="HasCategory('Externals')" />
+      <Setter Property="Background" Value="#FF424242" />
+      <Setter Property="Stroke" Value="#FF424242" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Inherits From" ValueLabel="True">
+      <Condition Expression="HasCategory('InheritsFrom')" />
+      <Setter Property="Stroke" Value="#FF00A600" />
+      <Setter Property="StrokeDashArray" Value="2 0" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Implements" ValueLabel="True">
+      <Condition Expression="HasCategory('Implements')" />
+      <Setter Property="Stroke" Value="#8000A600" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Calls" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_Calls')" />
+      <Setter Property="Stroke" Value="#FFFF00FF" />
+      <Setter Property="StrokeDashArray" Value="2 0" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Function Pointer" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FunctionPointer')" />
+      <Setter Property="Stroke" Value="#FFFF00FF" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Field Read" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FieldRead')" />
+      <Setter Property="Stroke" Value="#FF00AEEF" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Field Write" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FieldWrite')" />
+      <Setter Property="Stroke" Value="#FF00AEEF" />
+      <Setter Property="DrawArrow" Value="true" />
+      <Setter Property="IsHidden" Value="false" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Inherits From" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('InheritsFrom') And Target.HasCategory('CodeSchema_Class')" />
+      <Setter Property="TargetDecorator" Value="OpenArrow" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Implements" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('Implements') And Target.HasCategory('CodeSchema_Interface')" />
+      <Setter Property="TargetDecorator" Value="OpenArrow" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Comment Link" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="Source.HasCategory('Comment')" />
+      <Setter Property="Stroke" Value="#FFE5C365" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Cursor Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsCursorLocation" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Disabled Breakpoint Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="DisabledBreakpointCount" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Enabled Breakpoint Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="EnabledBreakpointCount" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Instruction Pointer Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsInstructionPointerLocation" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Current Callstack Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsCurrentCallstackFrame" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Return" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeSchema_ReturnTypeLink')" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="References" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('References')" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Uses Attribute" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeSchema_AttributeUse')" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Solution Folder" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeMap_SolutionFolder')" />
+      <Setter Property="Background" Value="#FFDEBA83" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Project Reference" ValueLabel="Project Reference">
+      <Condition Expression="HasCategory('CodeMap_ProjectReference')" />
+      <Setter Property="Stroke" Value="#9A9A9A" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="External Reference" ValueLabel="External Reference">
+      <Condition Expression="HasCategory('CodeMap_ExternalReference')" />
+      <Setter Property="Stroke" Value="#9A9A9A" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+  </Styles>
+  <Paths>
+    <Path Id="36f4bdc6-d3da-403a-8db7-0c79f94b938f.OutputPath" Value="C:\Users\ghuka\OneDrive\Documents\Git\CREXi\RateLimiter\bin\Debug\RateLimiter.dll" />
+    <Path Id="36f4bdc6-d3da-403a-8db7-0c79f94b938f.OutputPathUri" Value="file:///C:/Users/ghuka/OneDrive/Documents/Git/CREXi/RateLimiter/bin/Debug/RateLimiter.dll" />
+    <Path Id="c4f9249b-010e-46be-94b8-dd20d82f1e60.OutputPath" Value="C:\Users\ghuka\OneDrive\Documents\Git\CREXi\RateLimiter.Tests\bin\Debug\RateLimiter.Tests.dll" />
+    <Path Id="c4f9249b-010e-46be-94b8-dd20d82f1e60.OutputPathUri" Value="file:///C:/Users/ghuka/OneDrive/Documents/Git/CREXi/RateLimiter.Tests/bin/Debug/RateLimiter.Tests.dll" />
+    <Path Id="f1a9162d-6b41-4afb-afaa-eea62d2040de.OutputPath" Value="C:\Users\ghuka\OneDrive\Documents\Git\CREXi\RateLimiter.Api\bin\RateLimiter.Api.dll" />
+    <Path Id="f1a9162d-6b41-4afb-afaa-eea62d2040de.OutputPathUri" Value="file:///C:/Users/ghuka/OneDrive/Documents/Git/CREXi/RateLimiter.Api/bin/RateLimiter.Api.dll" />
+    <Path Id="FxReferenceAssembliesUri" Value="file:///C:/Program Files (x86)/Reference Assemblies/Microsoft/Framework" />
+    <Path Id="VsSolutionUri" Value="file:///C:/Users/ghuka/OneDrive/Documents/Git/CREXi" />
+  </Paths>
+</DirectedGraph>

--- a/RateLimiter.Api/App_Start/BundleConfig.cs
+++ b/RateLimiter.Api/App_Start/BundleConfig.cs
@@ -1,0 +1,14 @@
+﻿using System.Web;
+using System.Web.Optimization;
+
+namespace RateLimiter.Api
+{
+    public class BundleConfig
+    {
+        // For more information on bundling, visit https://go.microsoft.com/fwlink/?LinkId=301862
+        public static void RegisterBundles(BundleCollection bundles)
+        {
+            
+        }
+    }
+}

--- a/RateLimiter.Api/App_Start/FilterConfig.cs
+++ b/RateLimiter.Api/App_Start/FilterConfig.cs
@@ -1,0 +1,13 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+namespace RateLimiter.Api
+{
+    public class FilterConfig
+    {
+        public static void RegisterGlobalFilters(GlobalFilterCollection filters)
+        {
+            filters.Add(new HandleErrorAttribute());
+        }
+    }
+}

--- a/RateLimiter.Api/App_Start/RouteConfig.cs
+++ b/RateLimiter.Api/App_Start/RouteConfig.cs
@@ -1,0 +1,23 @@
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Web;
+//using System.Web.Mvc;
+//using System.Web.Routing;
+
+//namespace RateLimiter.Api
+//{
+//    public class RouteConfig
+//    {
+//        public static void RegisterRoutes(RouteCollection routes)
+//        {
+//            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
+//            routes.MapRoute(
+//                name: "Default",
+//                url: "{controller}/{action}/{id}",
+//                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+//            );
+//        }
+//    }
+//}

--- a/RateLimiter.Api/App_Start/WebApiConfig.cs
+++ b/RateLimiter.Api/App_Start/WebApiConfig.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+
+namespace RateLimiter.Api
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/RateLimiter.Api/Attributes/ValidateRateLimitAttribute.cs
+++ b/RateLimiter.Api/Attributes/ValidateRateLimitAttribute.cs
@@ -1,0 +1,35 @@
+﻿using RateLimiter.Api.Validators;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+
+namespace RateLimiter.Api.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
+    public class ValidateRateLimitAttribute : AuthorizeAttribute
+    {
+        /// <summary>
+        /// Apply rules that limit the timespan between valid requests to the API.
+        /// </summary>
+        public bool ApplyTimeRules { get; }
+
+        /// <summary>
+        /// Apply rules that limit the number of consecutive valid requests to the API per a period of time.
+        /// </summary>
+        public bool ApplyQuantityRules { get; }
+
+        public ValidateRateLimitAttribute(bool applyTimeRules = false, bool applyQuantityRules = false)
+        {
+            ApplyTimeRules = applyTimeRules;
+            ApplyQuantityRules = applyQuantityRules;
+        }
+
+        public override Task OnAuthorizationAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+        {
+            RequestValidator.ValidateRequest();
+            return base.OnAuthorizationAsync(actionContext, cancellationToken);
+        }
+    }
+}

--- a/RateLimiter.Api/Controllers/ValuesController.cs
+++ b/RateLimiter.Api/Controllers/ValuesController.cs
@@ -1,0 +1,39 @@
+﻿using RateLimiter.Api.Attributes;
+using System.Collections.Generic;
+using System.Web.Http;
+
+namespace RateLimiter.Api.Controllers
+{
+    public class ValuesController : ApiController
+    {
+        // GET api/values
+        [ValidateRateLimit(applyTimeRules: false, applyQuantityRules: true)]
+        public IEnumerable<string> Get()
+        {
+            return new[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [ValidateRateLimit(applyTimeRules: true, applyQuantityRules: false)]
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        [ValidateRateLimit(applyTimeRules: true, applyQuantityRules: true)]
+        public void Post([FromBody]string value)
+        {
+        }
+
+        // PUT api/values/5
+        public void Put(int id, [FromBody]string value)
+        {
+        }
+
+        // DELETE api/values/5
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/RateLimiter.Api/Global.asax
+++ b/RateLimiter.Api/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="RateLimiter.Api.WebApiApplication" Language="C#" %>

--- a/RateLimiter.Api/Global.asax.cs
+++ b/RateLimiter.Api/Global.asax.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Web.Mvc;
+using System.Web.Optimization;
+using System.Web.Routing;
+
+namespace RateLimiter.Api
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            AreaRegistration.RegisterAllAreas();
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+            FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
+            BundleConfig.RegisterBundles(BundleTable.Bundles);
+        }
+    }
+}

--- a/RateLimiter.Api/Properties/AssemblyInfo.cs
+++ b/RateLimiter.Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RateLimiter.Api")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RateLimiter.Api")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2b0fe693-e17b-4da2-b777-41938d7d7a26")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RateLimiter.Api/RateLimiter.Api.csproj
+++ b/RateLimiter.Api/RateLimiter.Api.csproj
@@ -1,0 +1,200 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RateLimiter.Api</RootNamespace>
+    <AssemblyName>RateLimiter.Api</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <MvcBuildViews>false</MvcBuildViews>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort>44391</IISExpressSSLPort>
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest">
+    </Reference>
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Optimization">
+      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="WebGrease">
+      <Private>True</Private>
+      <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
+    </Reference>
+    <Reference Include="Antlr3.Runtime">
+      <Private>True</Private>
+      <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\BundleConfig.cs" />
+    <Compile Include="App_Start\FilterConfig.cs" />
+    <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Attributes\ValidateRateLimitAttribute.cs" />
+    <Compile Include="Controllers\ValuesController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Validators\RequestValidator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+    <Content Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RateLimiter\RateLimiter.csproj">
+      <Project>{36f4bdc6-d3da-403a-8db7-0c79f94b938f}</Project>
+      <Name>RateLimiter</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
+  </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>54919</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>https://localhost:44391/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target> -->
+</Project>

--- a/RateLimiter.Api/RateLimiter.Api.csproj.user
+++ b/RateLimiter.Api/RateLimiter.Api.csproj.user
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort>44391</IISExpressSSLPort>
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+  </PropertyGroup>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <StartPageUrl>
+          </StartPageUrl>
+          <StartAction>CurrentPage</StartAction>
+          <AspNetDebugging>True</AspNetDebugging>
+          <SilverlightDebugging>False</SilverlightDebugging>
+          <NativeDebugging>False</NativeDebugging>
+          <SQLDebugging>False</SQLDebugging>
+          <ExternalProgram>
+          </ExternalProgram>
+          <StartExternalURL>
+          </StartExternalURL>
+          <StartCmdLineArguments>
+          </StartCmdLineArguments>
+          <StartWorkingDirectory>
+          </StartWorkingDirectory>
+          <EnableENC>True</EnableENC>
+          <AlwaysStartWebServerOnDebug>False</AlwaysStartWebServerOnDebug>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/RateLimiter.Api/Validators/RequestValidator.cs
+++ b/RateLimiter.Api/Validators/RequestValidator.cs
@@ -31,7 +31,7 @@ namespace RateLimiter.Api.Validators
                 }
                 catch (Exception)
                 {
-                    Debug.WriteLine($"Simulatioin failed for the rule {RuleTypes.FrequencyLimiting}");
+                    Debug.WriteLine($"Validation failed for the rule {RuleTypes.FrequencyLimiting}");
 
                     return false;
                 }
@@ -44,7 +44,7 @@ namespace RateLimiter.Api.Validators
                 }
                 catch (Exception)
                 {
-                    Debug.WriteLine($"Simulatioin failed for the rule {RuleTypes.FrequencyLimiting}");
+                    Debug.WriteLine($"Validation failed for the rule {RuleTypes.FrequencyLimiting}");
 
                     return false;
                 }
@@ -57,7 +57,7 @@ namespace RateLimiter.Api.Validators
                 }
                 catch (Exception)
                 {
-                    Debug.WriteLine($"Simulatioin failed for the rule {RuleTypes.TimeSpanLimiting}");
+                    Debug.WriteLine($"Validation failed for the rule {RuleTypes.TimeSpanLimiting}");
 
                     return false;
                 }

--- a/RateLimiter.Api/Validators/RequestValidator.cs
+++ b/RateLimiter.Api/Validators/RequestValidator.cs
@@ -1,0 +1,73 @@
+﻿using RateLimiter.Api.Attributes;
+using RateLimiter.Api.Controllers;
+using RateLimiter.Enums;
+using RateLimiter.Utilities;
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace RateLimiter.Api.Validators
+{
+    public class RequestValidator
+    {
+        public static bool ValidateRequest()
+        {
+            var attribute = GetAttribute(typeof(ValuesController));
+
+            if (attribute == null)
+            {
+                return true;
+            }
+
+            if (!attribute.ApplyQuantityRules && !attribute.ApplyTimeRules)
+            {
+                return true;
+            }
+            else if (attribute.ApplyQuantityRules && attribute.ApplyTimeRules)
+            {
+                try
+                {
+                    return RuleValidator.ValidateByType(RuleTypes.FrequencyTimeSpanLimiting);
+                }
+                catch (Exception)
+                {
+                    Debug.WriteLine($"Simulatioin failed for the rule {RuleTypes.FrequencyLimiting}");
+
+                    return false;
+                }
+            }
+            else if (attribute.ApplyQuantityRules)
+            {
+                try
+                {
+                    return RuleValidator.ValidateByType(RuleTypes.FrequencyLimiting);
+                }
+                catch (Exception)
+                {
+                    Debug.WriteLine($"Simulatioin failed for the rule {RuleTypes.FrequencyLimiting}");
+
+                    return false;
+                }
+            }
+            else
+            {
+                try
+                {
+                    return RuleValidator.ValidateByType(RuleTypes.TimeSpanLimiting);
+                }
+                catch (Exception)
+                {
+                    Debug.WriteLine($"Simulatioin failed for the rule {RuleTypes.TimeSpanLimiting}");
+
+                    return false;
+                }
+            }
+        }
+
+        private static ValidateRateLimitAttribute GetAttribute(MemberInfo memberInfo)
+        {
+            // Get instance of the attribute.
+            return (ValidateRateLimitAttribute)Attribute.GetCustomAttribute(memberInfo, typeof(ValidateRateLimitAttribute));
+        }
+    }
+}

--- a/RateLimiter.Api/Web.Debug.config
+++ b/RateLimiter.Api/Web.Debug.config
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0"?>
+
+<!-- For more information on using Web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=301874 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator
+    finds an attribute "name" that has a value of "MyDB".
+
+    <connectionStrings>
+      <add name="MyDB"
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire
+      <customErrors> section of your Web.config file.
+      Note that because there is only one customErrors section under the
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/RateLimiter.Api/Web.Release.config
+++ b/RateLimiter.Api/Web.Release.config
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0"?>
+
+<!-- For more information on using Web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=301874 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator
+    finds an attribute "name" that has a value of "MyDB".
+
+    <connectionStrings>
+      <add name="MyDB"
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire
+      <customErrors> section of your Web.config file.
+      Note that because there is only one customErrors section under the
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/RateLimiter.Api/Web.config
+++ b/RateLimiter.Api/Web.config
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <appSettings>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.7.2" />
+    <httpRuntime targetFramework="4.7.2" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/RateLimiter.Api/packages.config
+++ b/RateLimiter.Api/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net472" />
+  <package id="jQuery" version="3.4.1" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Modernizr" version="2.8.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
+  <package id="WebGrease" version="1.6.0" targetFramework="net472" />
+</packages>

--- a/RateLimiter.Tests/RateLimiter.Tests.csproj
+++ b/RateLimiter.Tests/RateLimiter.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,11 +35,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -51,9 +65,14 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\RateLimiter.Api\RateLimiter.Api.csproj">
+      <Project>{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}</Project>
+      <Name>RateLimiter.Api</Name>
+    </ProjectReference>
     <ProjectReference Include="..\RateLimiter\RateLimiter.csproj">
       <Project>{36f4bdc6-d3da-403a-8db7-0c79f94b938f}</Project>
       <Name>RateLimiter</Name>
@@ -65,5 +84,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
 </Project>

--- a/RateLimiter.Tests/RateLimiterTest.cs
+++ b/RateLimiter.Tests/RateLimiterTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using RateLimiter.Api.Attributes;
 
 namespace RateLimiter.Tests
 {

--- a/RateLimiter.Tests/app.config
+++ b/RateLimiter.Tests/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/RateLimiter.Tests/packages.config
+++ b/RateLimiter.Tests/packages.config
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.4.0" targetFramework="net472" />
+  <package id="Moq" version="4.13.1" targetFramework="net472" />
   <package id="NUnit" version="3.12.0" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="3.16.1" targetFramework="net472" developmentDependency="true" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net472" />
 </packages>

--- a/RateLimiter.sln
+++ b/RateLimiter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter", "RateLimiter\RateLimiter.csproj", "{36F4BDC6-D3DA-403A-8DB7-0C79F94B938F}"
 EndProject
@@ -9,8 +9,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter.Tests", "RateLi
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9B206889-9841-4B5E-B79B-D5B2610CCCFF}"
 	ProjectSection(SolutionItems) = preProject
+		CodeMap.dgml = CodeMap.dgml
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter.Api", "RateLimiter.Api\RateLimiter.Api.csproj", "{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +29,10 @@ Global
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1A9162D-6B41-4AFB-AFAA-EEA62D2040DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RateLimiter/Data/SeedData.cs
+++ b/RateLimiter/Data/SeedData.cs
@@ -1,0 +1,23 @@
+﻿using RateLimiter.Models;
+using System;
+
+namespace RateLimiter.Data
+{
+    public static class SeedData
+    {
+        public static FrequencyLimitRule FrequencyLimitRule = new FrequencyLimitRule
+        {
+            NumberOfRequests = 2,
+            TimeSpanLimit = new TimeSpan(0, 0, 0, 5)
+        };
+
+        public static TimeSpanLimitRule TimeSpanLimitRule = new TimeSpanLimitRule
+        {
+            TimeSpanLimit = new TimeSpan(0, 0, 0, 3)
+        };
+
+        public static Guid Token1 = Guid.NewGuid();
+        public static Guid Token2 = Guid.NewGuid();
+        public static Guid Token3 = Guid.NewGuid();
+    }
+}

--- a/RateLimiter/Enums/RuleTypes.cs
+++ b/RateLimiter/Enums/RuleTypes.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RateLimiter.Enums
+{
+    public enum RuleTypes
+    {
+        FrequencyLimiting,
+        TimeSpanLimiting,
+        FrequencyTimeSpanLimiting
+    }
+}

--- a/RateLimiter/Enums/RuleTypes.cs
+++ b/RateLimiter/Enums/RuleTypes.cs
@@ -8,8 +8,19 @@ namespace RateLimiter.Enums
 {
     public enum RuleTypes
     {
+        /// <summary>
+        /// Rules that limit the number of requests per certain period of time.
+        /// </summary>
         FrequencyLimiting,
+
+        /// <summary>
+        /// Rule that limit the period of time between the requests.
+        /// </summary>
         TimeSpanLimiting,
+
+        /// <summary>
+        /// Rules that combine both limiting the number of requests and limiting the timespan between the requests.
+        /// </summary>
         FrequencyTimeSpanLimiting
     }
 }

--- a/RateLimiter/Models/BaseRule.cs
+++ b/RateLimiter/Models/BaseRule.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RateLimiter.Enums;
+
+namespace RateLimiter.Models
+{
+    public abstract class BaseRule
+    {
+        private readonly RuleTypes _ruleType;
+
+        protected BaseRule(RuleTypes ruleType)
+        {
+            _ruleType = ruleType;
+        }
+    }
+}

--- a/RateLimiter/Models/FrequencyLimitRule.cs
+++ b/RateLimiter/Models/FrequencyLimitRule.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RateLimiter.Enums;
+
+namespace RateLimiter.Models
+{
+    public class FrequencyLimitRule : BaseRule
+    {
+        public int NumberOfRequests { get; set; }
+        public TimeSpan TimeSpanLimit { get; set; }
+
+        public FrequencyLimitRule() : base(RuleTypes.FrequencyLimiting)
+        {
+        }
+    }
+}

--- a/RateLimiter/Models/TimeSpanLimitRule.cs
+++ b/RateLimiter/Models/TimeSpanLimitRule.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RateLimiter.Enums;
+
+namespace RateLimiter.Models
+{
+    public class TimeSpanLimitRule : BaseRule
+    {
+        public TimeSpan TimeSpanLimit { get; set; }
+
+        public TimeSpanLimitRule() : base(RuleTypes.TimeSpanLimiting)
+        {
+        }
+    }
+}

--- a/RateLimiter/RateLimiter.csproj
+++ b/RateLimiter/RateLimiter.csproj
@@ -41,7 +41,18 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Data\SeedData.cs" />
+    <Compile Include="Enums\RuleTypes.cs" />
+    <Compile Include="Utilities\HistoryHelper.cs" />
+    <Compile Include="Models\BaseRule.cs" />
+    <Compile Include="Models\FrequencyLimitRule.cs" />
+    <Compile Include="Models\TimeSpanLimitRule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\RuleValidator.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/RateLimiter/Utilities/HistoryHelper.cs
+++ b/RateLimiter/Utilities/HistoryHelper.cs
@@ -1,5 +1,4 @@
-﻿using RateLimiter.Enums;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace RateLimiter.Utilities

--- a/RateLimiter/Utilities/HistoryHelper.cs
+++ b/RateLimiter/Utilities/HistoryHelper.cs
@@ -1,0 +1,97 @@
+﻿using RateLimiter.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Utilities
+{
+    public static class HistoryHelper
+    {
+        private static readonly Dictionary<Guid, Queue<DateTime>> TimeSpanHistory = new Dictionary<Guid, Queue<DateTime>>();
+        private static readonly Dictionary<Guid, Queue<DateTime>> FrequencyHistory = new Dictionary<Guid, Queue<DateTime>>();
+
+        private static void Save(IDictionary<Guid, Queue<DateTime>> history, Guid token, DateTime currentDate)
+        {
+            if (history.ContainsKey(token))
+            {
+                history[token].Enqueue(currentDate);
+            }
+            else
+            {
+                var queue = new Queue<DateTime>();
+                queue.Enqueue(currentDate);
+
+                history.Add(token, queue);
+            }
+        }
+
+        private static void Cleanup(Dictionary<Guid, Queue<DateTime>> history, Guid token, DateTime currentDate, TimeSpan timeSpanLimit)
+        {
+            if (history.ContainsKey(token))
+            {
+                while (currentDate - history[token].Peek() > timeSpanLimit)
+                {
+                    history[token].Dequeue();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if the max number of requests per a given <paramref name="timeSpanLimit"/> is reached for current <paramref name="token"/>.
+        /// </summary>
+        /// <param name="token">Current token associated with the request.</param>
+        /// <param name="numberOfRequests">Number of requests allowed per given period of time.</param>
+        /// <param name="timeSpanLimit">Period of time the requests are allowed to be made.</param>
+        /// <returns>Boolean value indicating if the request has been made within the limitations.</returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static bool ValidateFrequency(Guid token, int numberOfRequests, TimeSpan timeSpanLimit)
+        {
+            var currentDate = DateTime.UtcNow;
+
+            if (FrequencyHistory.ContainsKey(token))
+            {
+                // Calling Cleanup to remove all history items older than timeSpanLimit.
+                Cleanup(FrequencyHistory, token, currentDate, timeSpanLimit);
+
+                // The number of remaining items in the history after the Cleanup should be less than numberOfRequests.
+                if (numberOfRequests <= FrequencyHistory[token].Count)
+                {
+                    return false;
+                }
+            }
+
+            Save(FrequencyHistory, token, currentDate);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if <paramref name="timeSpanLimit"/> has passed since the last request with <paramref name="token"/> was made./>
+        /// </summary>
+        /// <param name="token">Current token associated with the request.</param>
+        /// <param name="timeSpanLimit">The interval requests are allowed to be made.</param>
+        /// <returns>Boolean value indicating if the request has been made within the limitations.</returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static bool ValidateTimeSpan(Guid token, TimeSpan timeSpanLimit)
+        {
+            var currentDate = DateTime.UtcNow;
+
+            if (!TimeSpanHistory.ContainsKey(token))
+            {
+                return true;
+            }
+
+            // Cleanup should remove an item if the timeStamp is older than timeSpanLimit, thus making the queue empty.
+            Cleanup(TimeSpanHistory, token, currentDate, timeSpanLimit);
+
+            // The queue should be empty if the timeSpanLimit is awaited.
+            if (TimeSpanHistory[token].Count != 0)
+            {
+                return false;
+            }
+
+            Save(TimeSpanHistory, token, currentDate);
+
+            return true;
+        }
+    }
+}

--- a/RateLimiter/Utilities/RuleValidator.cs
+++ b/RateLimiter/Utilities/RuleValidator.cs
@@ -1,0 +1,35 @@
+﻿using RateLimiter.Data;
+using RateLimiter.Enums;
+using System;
+
+namespace RateLimiter.Utilities
+{
+    public static class RuleValidator
+    {
+        public static bool ValidateByType(RuleTypes ruleType)
+        {
+            switch (ruleType)
+            {
+                case RuleTypes.FrequencyLimiting:
+                    {
+                        return HistoryHelper.ValidateFrequency(SeedData.Token1, SeedData.FrequencyLimitRule.NumberOfRequests, SeedData.FrequencyLimitRule.TimeSpanLimit);
+                    }
+                case RuleTypes.TimeSpanLimiting:
+                    {
+                        return HistoryHelper.ValidateTimeSpan(SeedData.Token1, SeedData.TimeSpanLimitRule.TimeSpanLimit);
+
+                    }
+                case RuleTypes.FrequencyTimeSpanLimiting:
+                    {
+                        return HistoryHelper.ValidateFrequency(SeedData.Token1, SeedData.FrequencyLimitRule.NumberOfRequests, SeedData.FrequencyLimitRule.TimeSpanLimit)
+                            && HistoryHelper.ValidateTimeSpan(SeedData.Token1, SeedData.TimeSpanLimitRule.TimeSpanLimit);
+                    }
+                default:
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(ruleType), ruleType,
+                            "The specified value of RuleTypes does not exist.");
+                    }
+            }
+        }
+    }
+}

--- a/RateLimiter/app.config
+++ b/RateLimiter/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
The validation of rate limiting rules is triggered by applying a custom `ValidateRateLimitAttribute` attribute derived from `AuthorizeAttribute` class on the controller actions. This makes it possible to specify the types of the rules that should be checked before allowing an access to the resource e.g.

`// GET api/values`
`[ValidateRateLimit(applyTimeRules: false, applyQuantityRules: true)]`
`public IEnumerable<string> Get()`
`{`
`      return new[] { "value1", "value2" };`
`}`

In the example above the `Get()` will be executed when the rules that limit the quantity of the requests in a given time span are satisfied.

Rule types are held in the `enum` called `RuleTypes`. Each of the rules has a mandatory `RuleType` and is extending the `BaseRule`.

The argument values of the `ValidateRateLimitAttribute` are checked by `RequestValidator.ValidateRequest()` method which calls the `RuleValidator.ValidateByType()` for each of the `RuleType` passed as an argument.

The logic to calculate the time span between the requests as well as the number of requests per time span is implemented in `HistoryHelper` utility and is relying on `SeedData`.

The Api project is added for a proper demonstration purpose.