### PR TITLE
Implement RateLimit Solution

### DIFF
--- a/RateLimitAPI/Controllers/WeatherForecastController.cs
+++ b/RateLimitAPI/Controllers/WeatherForecastController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace RateLimitAPI.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/RateLimitAPI/Program.cs
+++ b/RateLimitAPI/Program.cs
@@ -1,0 +1,39 @@
+using RateLimitAPI;
+using RateLimiter.Classes;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddSingleton(RateLimitSetup.ConfigureRateLimiting());
+builder.Services.AddControllers(); 
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.UseHttpsRedirection();
+app.UseAuthorization();
+
+app.Use(async (context, next) =>
+{
+    var rateLimitManager = app.Services.GetRequiredService<RateLimitManager>();
+    string token = context.Request.Headers["Authorization"]; // Extract token as per API design
+    string path = context.Request.Path.Value;
+
+    if (rateLimitManager.IsRequestAllowed(token, path))
+    {
+        await next();
+    }
+    else
+    {
+        context.Response.StatusCode = 429; // Too Many Requests
+        await context.Response.WriteAsync("Rate limit exceeded. Please try again later.");
+    }
+});
+
+app.UseRouting();
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapControllers(); // Map controllers if using MVC
+});
+
+app.Run();

--- a/RateLimitAPI/Properties/launchSettings.json
+++ b/RateLimitAPI/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:64926",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "RateLimitAPI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "http://localhost:5270",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/RateLimitAPI/RateLimitAPI.csproj
+++ b/RateLimitAPI/RateLimitAPI.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RateLimitAPI/RateLimitSetup.cs
+++ b/RateLimitAPI/RateLimitSetup.cs
@@ -1,0 +1,31 @@
+﻿using RateLimiter.Classes;
+using RateLimiter.Classes.Rules;
+
+namespace RateLimitAPI
+{
+    public static class RateLimitSetup
+    {
+        public static RateLimitManager ConfigureRateLimiting()
+        {
+            var manager = new RateLimitManager();
+
+            // Rule for weatherforecast: Up to 10 requests per minute
+            manager.AddRule("/weatherforecast", new FixedNumberRule(10, TimeSpan.FromMinutes(1)));
+
+            // Rule for Resource2: No more than 1 request per 30 seconds
+            manager.AddRule("/api/resource2", new TimeSpanSinceLastCallRule(TimeSpan.FromSeconds(30)));
+
+            // Rule for Resource3: Combination of FixedWindow and TimeSpan since last call
+            manager.AddRule("/api/resource3", new FixedNumberRule(5, TimeSpan.FromMinutes(1)));
+            manager.AddRule("/api/resource3", new TimeSpanSinceLastCallRule(TimeSpan.FromSeconds(10)));
+
+            // Rule for Resource4: Geographic conditional rules
+            var usRule = new FixedNumberRule(20, TimeSpan.FromMinutes(1));
+            var euRule = new TimeSpanSinceLastCallRule(TimeSpan.FromMinutes(5));
+            Func<string, string> getRegion = token => token.StartsWith("US") ? "US" : "EU";
+            manager.AddRule("/api/resource4", new GeographicConditionalRule(usRule, euRule, getRegion));
+
+            return manager;
+        }
+    }
+}

--- a/RateLimitAPI/WeatherForecast.cs
+++ b/RateLimitAPI/WeatherForecast.cs
@@ -1,0 +1,13 @@
+namespace RateLimitAPI
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string? Summary { get; set; }
+    }
+}

--- a/RateLimitAPI/appsettings.Development.json
+++ b/RateLimitAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/RateLimitAPI/appsettings.json
+++ b/RateLimitAPI/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/RateLimiter.Tests/RateLimiter.Tests.csproj
+++ b/RateLimiter.Tests/RateLimiter.Tests.csproj
@@ -8,8 +8,8 @@
     <ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>  

--- a/RateLimiter.Tests/RateLimiterTest.cs
+++ b/RateLimiter.Tests/RateLimiterTest.cs
@@ -1,13 +1,120 @@
 ﻿using NUnit.Framework;
+using RateLimiter.Classes;
+using RateLimiter.Classes.Rules;
+using System;
+using System.Threading;
 
 namespace RateLimiter.Tests;
 
 [TestFixture]
 public class RateLimiterTest
 {
-	[Test]
-	public void Example()
-	{
-		Assert.That(true, Is.True);
-	}
+    private TimeSpanSinceLastCallRule _timeSpanRule;
+    private FixedNumberRule _usRule;
+    private TimeSpanSinceLastCallRule _euRule;
+    private GeographicConditionalRule _geoRule;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Clear MemoryStore before each test
+        MemoryStore.Requests.Clear();
+        _timeSpanRule = new TimeSpanSinceLastCallRule(TimeSpan.FromSeconds(1));
+        _usRule = new FixedNumberRule(2, TimeSpan.FromMinutes(1));
+        _euRule = new TimeSpanSinceLastCallRule(TimeSpan.FromSeconds(1));
+        Func<string, string> getRegion = token => token.StartsWith("US") ? "US" : "EU";
+
+        _geoRule = new GeographicConditionalRule(_usRule, _euRule, getRegion);
+    }
+
+    [Test]
+    public void FixedNumberRule_AllowsRequestUnderLimit()
+    {
+        var rule = new FixedNumberRule(5, TimeSpan.FromMinutes(1));
+        bool result = rule.IsRequestAllowed("token1", "resource1");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void FixedNumberRule_BlocksRequestOverLimit()
+    {
+        var rule = new FixedNumberRule(1, TimeSpan.FromMinutes(1));
+        rule.IsRequestAllowed("token1", "resource1");
+        bool result = rule.IsRequestAllowed("token1", "resource1");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void RateLimitManager_AllowsRequestWithNoRules()
+    {
+        var manager = new RateLimitManager();
+        bool result = manager.IsRequestAllowed("token1", "resource1");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void FixedNumberRule_ShouldAllow_ThreeRequestsInLimit()
+    {
+        var rule = new FixedNumberRule(3, TimeSpan.FromMinutes(1));
+        var token = "user1";
+        var resource = "api/resource";
+
+        // First request should pass
+        Assert.That(rule.IsRequestAllowed(token, resource), Is.True);
+
+        // Second request should also pass
+        Assert.That(rule.IsRequestAllowed(token, resource), Is.True);
+
+        // Third request should also pass
+        Assert.That(rule.IsRequestAllowed(token, resource), Is.True);
+    }
+
+    [Test]
+    public void RateLimitManager_EnforcesMultipleRules()
+    {
+        var manager = new RateLimitManager();
+        var shortRule = new FixedNumberRule(1, TimeSpan.FromSeconds(1));  // Short window for test speed
+
+        manager.AddRule("resource1", shortRule);
+
+        Assert.That(manager.IsRequestAllowed("token1", "resource1"), Is.True, "First request should pass.");
+        Thread.Sleep(1100);  // Wait for more than 1 second
+        Assert.That(manager.IsRequestAllowed("token1", "resource1"), Is.True, "Second request should pass after window reset.");
+        Assert.That(manager.IsRequestAllowed("token1", "resource1"), Is.False,"Second request should fail.");
+    }
+
+    [Test]
+    public void ShouldAllow_FirstRequest()
+    {
+        var result = _timeSpanRule.IsRequestAllowed("token1", "resource1");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldBlock_RequestIfWithinTimeSpan()
+    {
+        _timeSpanRule.IsRequestAllowed("token1", "resource1"); // First request
+        Thread.Sleep(900); // Wait slightly more than 1 second
+        var result = _timeSpanRule.IsRequestAllowed("token1", "resource1"); // Second request immediately
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ShouldApply_USRule_ForUSTokens()
+    {
+        Assert.That(_geoRule.IsRequestAllowed("US123", "resource1"), Is.True); // First request
+        Thread.Sleep(1100); // Ensure passing the minimum time span
+        Assert.That(_geoRule.IsRequestAllowed("US123", "resource1"), Is.True); // Second request
+        Assert.That(_geoRule.IsRequestAllowed("US123", "resource1"), Is.False); // Third request
+    }
+
+    [Test]
+    public void ShouldApply_EURule_ForEUTokens()
+    {
+        Assert.That(_geoRule.IsRequestAllowed("EU123", "resource1"), Is.True); // First request
+        Thread.Sleep(1100); // Ensure passing the minimum time span
+        Assert.That(_geoRule.IsRequestAllowed("EU123", "resource1"), Is.True); // Second request
+        Assert.That(_geoRule.IsRequestAllowed("EU123", "resource1"), Is.False); // Immediate third request
+    }
+
 }

--- a/RateLimiter.sln
+++ b/RateLimiter.sln
@@ -1,16 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34622.214
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter", "RateLimiter\RateLimiter.csproj", "{36F4BDC6-D3DA-403A-8DB7-0C79F94B938F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RateLimiter", "RateLimiter\RateLimiter.csproj", "{36F4BDC6-D3DA-403A-8DB7-0C79F94B938F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter.Tests", "RateLimiter.Tests\RateLimiter.Tests.csproj", "{C4F9249B-010E-46BE-94B8-DD20D82F1E60}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RateLimiter.Tests", "RateLimiter.Tests\RateLimiter.Tests.csproj", "{C4F9249B-010E-46BE-94B8-DD20D82F1E60}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9B206889-9841-4B5E-B79B-D5B2610CCCFF}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimitAPI", "RateLimitAPI\RateLimitAPI.csproj", "{9FB1A438-1732-40D9-8FF9-AE7D5EF25E41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +28,10 @@ Global
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FB1A438-1732-40D9-8FF9-AE7D5EF25E41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FB1A438-1732-40D9-8FF9-AE7D5EF25E41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FB1A438-1732-40D9-8FF9-AE7D5EF25E41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FB1A438-1732-40D9-8FF9-AE7D5EF25E41}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RateLimiter/Classes/MemoryStore.cs
+++ b/RateLimiter/Classes/MemoryStore.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Classes
+{
+    // A memory storage to simulate a database
+    public static class MemoryStore
+    {
+        public static Dictionary<string, List<DateTime>> Requests = new();
+    }
+}

--- a/RateLimiter/Classes/RateLimitManager.cs
+++ b/RateLimiter/Classes/RateLimitManager.cs
@@ -1,0 +1,38 @@
+﻿using RateLimiter.Interfaces;
+using System.Collections.Generic;
+
+namespace RateLimiter.Classes
+{
+    // Manager class for rate limiting
+    public class RateLimitManager
+    {
+        private readonly Dictionary<string, List<IRateLimitRule>> _rules = new();
+
+        public void AddRule(string resource, IRateLimitRule rule)
+        {
+            if (_rules.ContainsKey(resource))
+            {
+                _rules[resource].Add(rule);
+            }
+            else
+            {
+                _rules[resource] = new List<IRateLimitRule> { rule };
+            }
+        }
+
+        public bool IsRequestAllowed(string token, string resource)
+        {
+            if (!_rules.ContainsKey(resource)) return true;  // No limit if no rules defined
+
+            foreach (var rule in _rules[resource])
+            {
+                if (!rule.IsRequestAllowed(token, resource))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/RateLimiter/Classes/Rules/FixedNumberRule.cs
+++ b/RateLimiter/Classes/Rules/FixedNumberRule.cs
@@ -1,0 +1,38 @@
+﻿using RateLimiter.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Classes.Rules
+{
+    public class FixedNumberRule : IRateLimitRule
+    {
+        private readonly int _requestLimit;
+        private readonly TimeSpan _timeSpan;
+
+        public FixedNumberRule(int requestLimit, TimeSpan timeSpan)
+        {
+            _requestLimit = requestLimit;
+            _timeSpan = timeSpan;
+        }
+
+        public bool IsRequestAllowed(string token, string resource)
+        {
+            var key = $"{resource}:{token}";
+            if (!MemoryStore.Requests.ContainsKey(key))
+            {
+                MemoryStore.Requests[key] = new List<DateTime> { DateTime.Now };
+                return true;
+            }
+
+            var requests = MemoryStore.Requests[key];
+            requests.RemoveAll(dt => dt < DateTime.Now - _timeSpan);
+            if (requests.Count < _requestLimit)
+            {
+                requests.Add(DateTime.Now);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/RateLimiter/Classes/Rules/GeographicConditionalRule.cs
+++ b/RateLimiter/Classes/Rules/GeographicConditionalRule.cs
@@ -1,0 +1,30 @@
+﻿using RateLimiter.Interfaces;
+using System;
+
+namespace RateLimiter.Classes.Rules
+{
+    public class GeographicConditionalRule : IRateLimitRule
+    {
+        private readonly IRateLimitRule _usRule;
+        private readonly IRateLimitRule _euRule;
+        private readonly Func<string, string> _getRegionByToken;
+
+        public GeographicConditionalRule(IRateLimitRule usRule, IRateLimitRule euRule, Func<string, string> getRegionByToken)
+        {
+            _usRule = usRule;
+            _euRule = euRule;
+            _getRegionByToken = getRegionByToken;
+        }
+
+        public bool IsRequestAllowed(string token, string resource)
+        {
+            var region = _getRegionByToken(token);
+            return region switch
+            {
+                "US" => _usRule.IsRequestAllowed(token, resource),
+                "EU" => _euRule.IsRequestAllowed(token, resource),
+                _ => true, // Default to allow if region not recognized
+            };
+        }
+    }
+}

--- a/RateLimiter/Classes/Rules/TimeSpanSinceLastCallRule.cs
+++ b/RateLimiter/Classes/Rules/TimeSpanSinceLastCallRule.cs
@@ -1,0 +1,36 @@
+﻿using RateLimiter.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RateLimiter.Classes.Rules
+{
+    public class TimeSpanSinceLastCallRule : IRateLimitRule
+    {
+        private readonly TimeSpan _minTimeSpanBetweenCalls;
+
+        public TimeSpanSinceLastCallRule(TimeSpan minTimeSpanBetweenCalls)
+        {
+            _minTimeSpanBetweenCalls = minTimeSpanBetweenCalls;
+        }
+
+        public bool IsRequestAllowed(string token, string resource)
+        {
+            var key = $"{resource}:{token}";
+            if (!MemoryStore.Requests.ContainsKey(key) || !MemoryStore.Requests[key].Any())
+            {
+                MemoryStore.Requests[key] = new List<DateTime> { DateTime.Now };
+                return true;
+            }
+
+            var lastRequestTime = MemoryStore.Requests[key].Last();
+            if (DateTime.Now - lastRequestTime >= _minTimeSpanBetweenCalls)
+            {
+                MemoryStore.Requests[key].Add(DateTime.Now);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/RateLimiter/Interfaces/IRateLimitRule.cs
+++ b/RateLimiter/Interfaces/IRateLimitRule.cs
@@ -1,0 +1,8 @@
+﻿namespace RateLimiter.Interfaces
+{
+    // Interface defining the structure for rate limiting rules
+    public interface IRateLimitRule
+    {
+        bool IsRequestAllowed(string token, string resource);
+    }
+}


### PR DESCRIPTION
-  API endpoint can be limited by a FixedNumberRule
-  Can be governed by both a FixedNumberRule and a TimeSpanSinceLastCallRule, or any other combination. 
-  RateLimitManager supports adding multiple rules for any given resource.
-  By Utilizing the IRateLimitRule interface it can easily introduce new types of rate-limiting rules without modifying the existing codebase. 
- Any new rule just needs to implement the IRateLimitRule interface. 