### PR TITLE
Implement Rate Limiter with Unit tests

### DIFF
--- a/RateLimiter.Tests/RateLimiter.Tests.csproj
+++ b/RateLimiter.Tests/RateLimiter.Tests.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>

--- a/RateLimiter.Tests/RateLimiterTest.cs
+++ b/RateLimiter.Tests/RateLimiterTest.cs
@@ -1,13 +1,124 @@
-﻿using NUnit.Framework;
+﻿using Moq;
+using NUnit.Framework;
+using RateLimiter.Rules;
+using System.Collections.Generic;
 
 namespace RateLimiter.Tests;
 
 [TestFixture]
 public class RateLimiterTest
 {
-	[Test]
-	public void Example()
+	private readonly List<Mock<IRateLimitRule>> _rateLimitRuleMocks = new List<Mock<IRateLimitRule>>
 	{
-		Assert.That(true, Is.True);
+		new(),
+		new()
+	};
+
+    [Test]
+    public void IsRequestAllowed_NoRulesForResource_ReturnsTrue()
+    {
+        // arrange
+        string resource = "resource";
+        string token = "token";
+
+        var rateLimiter = new RateLimiter(new Dictionary<string, ICollection<IRateLimitRule>>
+        {
+        });
+
+        // act
+        // assert
+        Assert.True(rateLimiter.IsRequestAllowed(token, resource));
+    }
+
+    [Test]
+    public void IsRequestAllowed_AllRulesPass_ReturnsTrue()
+    {
+        // arrange
+        string resource = "resource";
+        string token = "token";
+        var key = $"{resource}:{token}";
+
+        _rateLimitRuleMocks[0].Setup(x => x.IsRequestAllowed(resource, token)).Returns(true);
+        _rateLimitRuleMocks[1].Setup(x => x.IsRequestAllowed(resource, token)).Returns(true);
+
+        var rateLimiter = new RateLimiter(new Dictionary<string, ICollection<IRateLimitRule>>
+        {
+            {
+                resource,
+                new List<IRateLimitRule> { _rateLimitRuleMocks[0].Object, _rateLimitRuleMocks[1].Object }
+            }
+        });
+
+        // act
+        // assert
+        Assert.True(rateLimiter.IsRequestAllowed(token, resource));
+    }
+
+    [Test]
+	public void IsRequestAllowed_OneRuleFails_ReturnsTrue()
+	{
+		// arrange
+		string resource = "resource";
+		string token = "token";
+        var key = $"{resource}:{token}";
+
+        _rateLimitRuleMocks[0].Setup(x => x.IsRequestAllowed(resource, token)).Returns(true);
+        _rateLimitRuleMocks[1].Setup(x => x.IsRequestAllowed(resource, token)).Returns(false);
+
+        // act
+        var rateLimiter = new RateLimiter(new Dictionary<string, ICollection<IRateLimitRule>>
+		{
+			{
+				resource,
+				new List<IRateLimitRule> { _rateLimitRuleMocks[0].Object, _rateLimitRuleMocks[1].Object }
+            }
+        });
+
+        // act
+        // assert
+        Assert.False(rateLimiter.IsRequestAllowed(resource, token));
 	}
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void AddRule_AddRuleForResource_NewRuleExecuted(bool isRequestAllowed)
+    {
+        // arrange
+        string resource = "resource";
+        string token = "token";
+
+        var rateLimiter = new RateLimiter(new Dictionary<string, ICollection<IRateLimitRule>>
+        {
+        });
+
+        _rateLimitRuleMocks[0].Setup(x => x.IsRequestAllowed(resource, token)).Returns(isRequestAllowed);
+
+        // act
+        rateLimiter.AddRule(resource, _rateLimitRuleMocks[0].Object);
+
+        // assert
+        Assert.AreEqual(rateLimiter.IsRequestAllowed(resource, token), isRequestAllowed);
+    }
+
+    [Test]
+    public void AddRule_AddRuleForResourceWithExistingRules_NewRuleExecuted()
+    {
+        // arrange
+        string resource = "resource";
+        string token = "token";
+
+        _rateLimitRuleMocks[0].Setup(x => x.IsRequestAllowed(resource, token)).Returns(true);
+        _rateLimitRuleMocks[1].Setup(x => x.IsRequestAllowed(resource, token)).Returns(false);
+
+        var rateLimiter = new RateLimiter(new Dictionary<string, ICollection<IRateLimitRule>>
+        {
+            { resource, new List<IRateLimitRule> { _rateLimitRuleMocks[0].Object } }
+        });
+
+        // act
+        rateLimiter.AddRule(resource, _rateLimitRuleMocks[1].Object);
+
+        // assert
+        Assert.AreEqual(rateLimiter.IsRequestAllowed(resource, token), false);
+    }
 }

--- a/RateLimiter.Tests/Rules/CountryBasedRuleTests.cs
+++ b/RateLimiter.Tests/Rules/CountryBasedRuleTests.cs
@@ -1,0 +1,105 @@
+﻿using Moq;
+using NUnit.Framework;
+using RateLimiter.Rules;
+using RateLimiter.Storage;
+using System.Collections.Generic;
+
+namespace RateLimiter.Tests.Rules
+{
+    [TestFixture]
+    public class CountryBasedRuleTests
+    {
+        [Test]
+        public void IsRequestAllowed_CountryWithoutRules_ReturnsTrue()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            string tokenCountry = "us";
+
+            DataStorage.TokenOrigins = new Dictionary<string, string>
+            {
+                { token, tokenCountry }
+            };
+
+            var rules = new Dictionary<string, IEnumerable<IRateLimitRule>>
+            {
+                { tokenCountry, new List<IRateLimitRule> { } }
+            };
+
+            var sut = new CountryBasedRule(rules);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.True(actualResult);
+        }
+
+        [Test]
+        public void IsRequestAllowed_CountryWithoutFailingRules_ReturnsTrue()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            string tokenCountry = "us";
+
+            DataStorage.TokenOrigins = new Dictionary<string, string>
+            {
+                { token, tokenCountry }
+            };
+
+            Mock<IRateLimitRule> rateLimiter = new Mock<IRateLimitRule>();
+            rateLimiter.Setup(x => x.IsRequestAllowed(resource, token))
+                .Returns(true);
+
+            var rules = new Dictionary<string, IEnumerable<IRateLimitRule>>
+            {
+                { tokenCountry, new List<IRateLimitRule> { rateLimiter.Object } }
+            };
+
+            var sut = new CountryBasedRule(rules);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.True(actualResult);
+        }
+
+        [Test]
+        public void IsRequestAllowed_CountryWithOneFailingRule_ReturnsFalse()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            string tokenCountry = "us";
+
+            DataStorage.TokenOrigins = new Dictionary<string, string>
+            {
+                { token, tokenCountry }
+            };
+            
+            var rateLimiter1 = new Mock<IRateLimitRule>();
+            rateLimiter1.Setup(x => x.IsRequestAllowed(resource, token))
+                .Returns(true);
+
+            var rateLimiter2 = new Mock<IRateLimitRule>();
+            rateLimiter2.Setup(x => x.IsRequestAllowed(resource, token))
+                .Returns(false);
+
+            var rules = new Dictionary<string, IEnumerable<IRateLimitRule>>
+            {
+                { tokenCountry, new List<IRateLimitRule> { rateLimiter1.Object, rateLimiter2.Object } }
+            };
+
+            var sut = new CountryBasedRule(rules);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.False(actualResult);
+        }
+    }
+}

--- a/RateLimiter.Tests/Rules/FixedRequestNumberRuleTests.cs
+++ b/RateLimiter.Tests/Rules/FixedRequestNumberRuleTests.cs
@@ -1,0 +1,89 @@
+﻿using NUnit.Framework;
+using RateLimiter.Rules;
+using RateLimiter.Storage;
+using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Tests.Rules
+{
+    [TestFixture]
+    public class FixedRequestNumberRuleTests
+    {
+        [Test]
+        public void IsRequestAllowed_FirstRequestForResourceToken_ReturnsTrue()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+
+            TimeSpan timeSpan = TimeSpan.FromMinutes(1);
+
+            var maxRequestCount = 1;
+
+            DataStorage.Requests = new Dictionary<string, List<DateTime>>
+            {
+            };
+
+            var sut = new FixedRequestNumberRule(timeSpan, maxRequestCount);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.True(actualResult);
+        }
+
+        [Test]
+        public void IsRequestAllowed_MaxRequestCountNotExceeded_ReturnsTrue()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            var key = $"{resource}:{token}";
+
+            TimeSpan timeSpan = TimeSpan.FromMinutes(1);
+
+            var maxRequestCount = 2;
+            var dateInLatestTimeSpan = DateTime.UtcNow;
+            var dateNotInLatestTimeSpan = DateTime.UtcNow.AddMinutes(-2);
+
+            DataStorage.Requests = new Dictionary<string, List<DateTime>>
+            {
+                { key, new List<DateTime> { dateNotInLatestTimeSpan, dateInLatestTimeSpan } }
+            };
+
+            var sut = new FixedRequestNumberRule(timeSpan, maxRequestCount);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.True(actualResult);
+        }
+
+        [Test]
+        public void IsRequestAllowed_MaxRequestCountExceeded_ReturnsFalse()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            var key = $"{resource}:{token}";
+
+            TimeSpan timeSpan = TimeSpan.FromMinutes(1);
+            var maxRequestCount = 1;
+
+            DataStorage.Requests = new Dictionary<string, List<DateTime>>
+            {
+                { key, new List<DateTime> { DateTime.UtcNow } }
+            };
+
+            var sut = new FixedRequestNumberRule(timeSpan, maxRequestCount);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.False(actualResult);
+        }
+    }
+}

--- a/RateLimiter.Tests/Rules/TimeSpanAfterLastCallRuleTests.cs
+++ b/RateLimiter.Tests/Rules/TimeSpanAfterLastCallRuleTests.cs
@@ -1,0 +1,82 @@
+﻿using NUnit.Framework;
+using RateLimiter.Rules;
+using RateLimiter.Storage;
+using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Tests.Rules
+{
+    [TestFixture]
+    public class TimeSpanAfterLastCallRuleTests
+    {
+        [Test]
+        public void IsRequestAllowed_NoRequestsForResourceToken_ReturnsTrue()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+
+            var timeSpan = TimeSpan.FromMinutes(1);
+
+            DataStorage.Requests = new Dictionary<string, List<DateTime>>
+            {
+            };
+
+            var sut = new TimeSpanAfterLastCallRule(timeSpan);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.True(actualResult);
+        }
+
+        [Test]
+        public void IsRequestAllowed_NoRequestsWithinTimeSpan_ReturnsTrue()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            var key = $"{resource}:{token}";
+
+            var timeSpan = TimeSpan.FromMinutes(1);
+
+            DataStorage.Requests = new Dictionary<string, List<DateTime>>
+            {
+                { key, new List<DateTime> { DateTime.UtcNow.AddMinutes(-3), DateTime.UtcNow.AddMinutes(-2) } }
+            };
+
+            var sut = new TimeSpanAfterLastCallRule(timeSpan);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.True(actualResult);
+        }
+
+        [Test]
+        public void IsRequestAllowed_RequestExistsWithinTimeSpan_ReturnsFalse()
+        {
+            // arrange
+            string resource = "resource";
+            string token = "token";
+            var key = $"{resource}:{token}";
+
+            var timeSpan = TimeSpan.FromMinutes(1);
+
+            DataStorage.Requests = new Dictionary<string, List<DateTime>>
+            {
+                { key, new List<DateTime> { DateTime.UtcNow.AddMinutes(-2), DateTime.UtcNow} }
+            };
+
+            var sut = new TimeSpanAfterLastCallRule(timeSpan);
+
+            // act
+            var actualResult = sut.IsRequestAllowed(resource, token);
+
+            // assert
+            Assert.False(actualResult);
+        }
+    }
+}

--- a/RateLimiter/RateLimiter.cs
+++ b/RateLimiter/RateLimiter.cs
@@ -1,0 +1,50 @@
+﻿using RateLimiter.Rules;
+using System.Collections.Generic;
+
+namespace RateLimiter
+{
+    public class RateLimiter
+    {
+        private readonly IDictionary<string, ICollection<IRateLimitRule>> _rules;
+
+        public RateLimiter() : this(new Dictionary<string, ICollection<IRateLimitRule>>())
+        {
+
+        }
+
+        public RateLimiter(IDictionary<string, ICollection<IRateLimitRule>> rules)
+        {
+            _rules = rules;
+        }
+
+        public void AddRule(string resource, IRateLimitRule rule)
+        {
+            if (_rules.TryGetValue(resource, out var rules))
+            {
+                rules.Add(rule);
+            }
+            else
+            {
+                _rules.Add(resource, [rule]);
+            }
+        }
+
+        public bool IsRequestAllowed(string resource, string token)
+        {
+            if (!_rules.ContainsKey(resource))
+            {
+                return true;
+            }
+
+            foreach (var rule in _rules[resource])
+            {
+                if (!rule.IsRequestAllowed(resource, token))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/RateLimiter/Rules/CountryBasedRule.cs
+++ b/RateLimiter/Rules/CountryBasedRule.cs
@@ -1,0 +1,30 @@
+﻿using RateLimiter.Storage;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RateLimiter.Rules
+{
+    /// <summary>
+    /// This rule is used to apply rules depending on the token origin country.
+    /// </summary>
+    public class CountryBasedRule : IRateLimitRule
+    {
+        private readonly Dictionary<string, IEnumerable<IRateLimitRule>> _rules;
+
+        public CountryBasedRule(Dictionary<string, IEnumerable<IRateLimitRule>> rules)
+        {
+            _rules = rules;
+        }
+
+        public bool IsRequestAllowed(string resource, string token)
+        {
+            var country = DataStorage.GetTokenOrigin(token);
+            if (!_rules.TryGetValue(country, out var rules))
+            {
+                return true;
+            }
+
+            return rules.All(x => x.IsRequestAllowed(resource, token));
+        }
+    }
+}

--- a/RateLimiter/Rules/FixedRequestNumberRule.cs
+++ b/RateLimiter/Rules/FixedRequestNumberRule.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System;
+using RateLimiter.Storage;
+using System.Linq;
+
+namespace RateLimiter.Rules
+{
+    /// <summary>
+    /// This rule is used to restrict number of requests during the defined timespan.
+    /// </summary>
+    public class FixedRequestNumberRule : IRateLimitRule
+    {
+        private readonly TimeSpan _timeSpan;
+        private readonly long _maxRequestCount;
+
+        public FixedRequestNumberRule(TimeSpan timeSpan, long maxRequestCount)
+        {
+            _timeSpan = timeSpan;
+            if (maxRequestCount <= 0)
+                throw new ArgumentOutOfRangeException("Max request count should not be less than 1");
+
+            _maxRequestCount = maxRequestCount;
+        }
+
+        public bool IsRequestAllowed(string resource, string token)
+        {
+            var dateNow = DateTime.UtcNow;
+
+            var key = $"{resource}:{token}";
+            bool newKeyAdded = DataStorage.Requests.TryAdd(key, new List<DateTime> { dateNow });
+            if (newKeyAdded)
+            {
+                return true;
+            }
+
+            var requests = DataStorage.Requests[key];
+            var requestsInLatestRange = requests.Count(req => req >= dateNow - _timeSpan);
+            if (requestsInLatestRange < _maxRequestCount)
+            {
+                requests.Add(dateNow);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/RateLimiter/Rules/IRateLimitRule.cs
+++ b/RateLimiter/Rules/IRateLimitRule.cs
@@ -1,0 +1,7 @@
+﻿namespace RateLimiter.Rules
+{
+    public interface IRateLimitRule
+    {
+        bool IsRequestAllowed(string resource, string token);
+    }
+}

--- a/RateLimiter/Rules/TimeSpanAfterLastCallRule.cs
+++ b/RateLimiter/Rules/TimeSpanAfterLastCallRule.cs
@@ -1,0 +1,41 @@
+﻿using RateLimiter.Storage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RateLimiter.Rules
+{
+    /// <summary>
+    /// This rule assure that a certain timespan passed since the last call for the resource.
+    /// </summary>
+    public class TimeSpanAfterLastCallRule : IRateLimitRule
+    {
+        private readonly TimeSpan _maxTimeSpanBetweenCalls;
+
+        public TimeSpanAfterLastCallRule(TimeSpan maxTimeSpanBetweenCalls)
+        {
+            _maxTimeSpanBetweenCalls = maxTimeSpanBetweenCalls;
+        }
+
+        public bool IsRequestAllowed(string resource, string token)
+        {
+            var dateNow = DateTime.UtcNow;
+            var key = $"{resource}:{token}";
+
+            var newKeyAdded = DataStorage.Requests.TryAdd(key, new List<DateTime> { DateTime.UtcNow });
+            if (newKeyAdded)
+            {
+                return true;
+            }
+
+            var lastRequestTime = DataStorage.Requests[key].Max();
+            if (dateNow - lastRequestTime >= _maxTimeSpanBetweenCalls)
+            {
+                DataStorage.Requests[key].Add(dateNow);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/RateLimiter/Storage/DataStorage.cs
+++ b/RateLimiter/Storage/DataStorage.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Storage
+{
+    public static class DataStorage
+    {
+        public static Dictionary<string, List<DateTime>> Requests { get; set; }
+
+        public static Dictionary<string, string> TokenOrigins { get; set; }
+
+        public static string GetTokenOrigin(string token)
+        {
+            return TokenOrigins[token];
+        }
+    }
+}


### PR DESCRIPTION
Implemented rate limiter with 3 types of rules:
1. Country Based Rule - Custom rules are applied based on token origin country
2. Fixed Request Number Rule - Rule, which allows specific max number of requests per timespan
3. Time Span After Last Call Rule - Rule, which allows requests within the timespan after the last request