### PR TITLE
Sunil Gudipelli

### DIFF
--- a/RateLimiter.Tests/RateLimiter.Tests.csproj
+++ b/RateLimiter.Tests/RateLimiter.Tests.csproj
@@ -1,15 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-  </ItemGroup>
-</Project>  
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="xunit" Version="2.5.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>

--- a/RateLimiter.Tests/RateLimiterConfigTests.cs
+++ b/RateLimiter.Tests/RateLimiterConfigTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+
+namespace RateLimiter.Tests;
+
+public class RateLimiterConfigTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void RateLimiterConfig_CacheExpirationInMinutes_ZeroOrNegative_ValidationFails(int cacheExpirationInMinutes)
+    {
+        // arrange
+        var config = new RateLimiterConfig()
+        {
+            CacheExpirationInMinutes = cacheExpirationInMinutes
+        };
+        var validator = new RateLimiterConfigValidator();
+
+        // act
+        var result = validator.Validate(config);
+
+        // assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(1);
+        result.Errors[0].ErrorMessage.Should().Be($"'Cache Expiration In Minutes' must be greater than '0'.");
+    }
+}

--- a/RateLimiter.Tests/RateLimiterTest.cs
+++ b/RateLimiter.Tests/RateLimiterTest.cs
@@ -1,13 +1,166 @@
-﻿using NUnit.Framework;
+﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RateLimiter.Rules;
 
 namespace RateLimiter.Tests;
 
-[TestFixture]
-public class RateLimiterTest
+public class RateLimiterTests
 {
-	[Test]
-	public void Example()
-	{
-		Assert.That(true, Is.True);
-	}
+    private readonly Mock<IMemoryCache> _mockCache;
+    private readonly Mock<IRateLimitRuleRepository> _mockRuleRepository;
+    private readonly RateLimiter _rateLimiter;
+    delegate void OutDelegate<TIn, TOut>(TIn input, out TOut output);
+
+    public RateLimiterTests()
+    {
+        _mockCache = new Mock<IMemoryCache>();
+        _mockRuleRepository = new Mock<IRateLimitRuleRepository>();
+        Mock<ILogger<RateLimiter>> mockLogger = new();
+        var mockRateLimiterConfig = new Mock<IOptions<RateLimiterConfig>>(MockBehavior.Loose);
+        mockRateLimiterConfig.Setup(m => m.Value).Returns(new RateLimiterConfig()
+        {
+            CacheExpirationInMinutes = 5
+        });
+        _rateLimiter = new RateLimiter(_mockCache.Object, _mockRuleRepository.Object, mockRateLimiterConfig.Object, mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task IsRequestAllowedAsync_CacheMiss_FetchesRulesFromDatabase()
+    {
+        // Arrange
+        var clientId = "client1";
+        var resource = "resource1";
+        var rules = new List<RateLimitRuleEntity>
+        {
+            new()
+            {
+                ClientId = clientId,
+                Resource = resource,
+                RuleType = RuleType.RequestCount,
+                MaxRequests = 10,
+                TimeSpan = TimeSpan.FromMinutes(1)
+            }
+        };
+
+        // Setup mocks
+        object? whatever;
+        _mockCache
+            .Setup(mc => mc.TryGetValue(It.IsAny<object>(), out whatever))
+            .Callback(new OutDelegate<object, object>((object _, out object v) =>
+                v = new object())) // mocked value here (and/or breakpoint)
+            .Returns(false);
+
+        var cacheEntry = Mock.Of<ICacheEntry>();
+        _mockCache
+            .Setup(m => m.CreateEntry(It.IsAny<object>()))
+            .Returns(cacheEntry);
+
+        _mockRuleRepository.Setup(repo => repo.GetRulesByClientId(clientId))
+            .ReturnsAsync(rules);
+
+        // Act
+        var result = await _rateLimiter.IsRequestAllowed(clientId, resource);
+
+        // Assert
+        Assert.True(result);
+        _mockRuleRepository.Verify(repo => repo.GetRulesByClientId(clientId), Times.Once);
+    }
+
+    [Fact]
+    public async Task IsRequestAllowedAsync_NoRulesInDatabase_DenyRequest()
+    {
+        // Arrange
+        var clientId = "client1";
+        var resource = "resource1";
+
+        // Setup mocks
+        object? whatever;
+        _mockCache
+            .Setup(mc => mc.TryGetValue(It.IsAny<object>(), out whatever))
+            .Callback(new OutDelegate<object, object>((object _, out object v) =>
+                v = new object())) // mocked value here (and/or breakpoint)
+            .Returns(false);
+
+        var cacheEntry = Mock.Of<ICacheEntry>();
+        _mockCache
+            .Setup(m => m.CreateEntry(It.IsAny<object>()))
+            .Returns(cacheEntry);
+
+        _mockRuleRepository.Setup(repo => repo.GetRulesByClientId(clientId))
+            .ReturnsAsync(new List<RateLimitRuleEntity>());
+
+        // Act
+        var result = await _rateLimiter.IsRequestAllowed(clientId, resource);
+
+        // Assert
+        Assert.False(result);
+        _mockRuleRepository.Verify(repo => repo.GetRulesByClientId(clientId), Times.Once);
+    }
+
+    [Fact]
+    public async Task IsRequestAllowedAsync_RulesAvailableInCache_AllowRequest()
+    {
+        // Arrange
+        var clientId = "client1";
+        var resource = "resource1";
+        var rules = new List<RateLimitRuleEntity>
+        {
+            new()
+            {
+                ClientId = clientId,
+                Resource = resource,
+                RuleType = RuleType.RequestCount,
+                MaxRequests = 10,
+                TimeSpan = TimeSpan.FromMinutes(1)
+            }
+        };
+
+        var ruleMock = new Mock<IRateLimitRule>();
+        ruleMock.Setup(rule => rule.IsRequestAllowed(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        object? whatever;
+        var callCount = 0;
+        _mockCache
+            .Setup(mc => mc.TryGetValue(It.IsAny<object>(), out whatever))
+            .Callback(new OutDelegate<object, object>((object _, out object v) =>
+            {
+                // On the first call, return an empty list
+                v = callCount == 0 ? new List<RateLimitRuleEntity>() : 
+                    // On the second call, return the populated list
+                    rules;
+
+                callCount++;
+            }))
+            .Returns(true);
+        var cacheEntry = Mock.Of<ICacheEntry>();
+        _mockCache
+            .Setup(m => m.CreateEntry(It.IsAny<object>()))
+            .Returns(cacheEntry);
+
+        _mockRuleRepository.Setup(repo => repo.GetRulesByClientId(clientId))
+            .ReturnsAsync(rules);
+
+        await _rateLimiter.IsRequestAllowed(clientId, resource);
+
+        // Act
+        var result = await _rateLimiter.IsRequestAllowed(clientId, resource);
+
+        // Assert
+        Assert.True(result);
+        _mockRuleRepository.Verify(repo => repo.GetRulesByClientId(clientId), Times.Once);
+    }
+
+    [Fact]
+    public async Task IsRequestAllowedAsync_InvalidInputs_ThrowsException()
+    {
+        // Arrange
+        var clientId = "";
+        var resource = "";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => _rateLimiter.IsRequestAllowed(clientId, resource));
+    }
 }

--- a/RateLimiter.Tests/RequestCountRuleTests.cs
+++ b/RateLimiter.Tests/RequestCountRuleTests.cs
@@ -1,0 +1,184 @@
+﻿using RateLimiter.Rules;
+using FluentAssertions;
+using System.Collections.Concurrent;
+
+namespace RateLimiter.Tests;
+
+public class RequestCountRuleTests
+{
+    [Fact]
+    public async Task Should_Allows_Requests_Within_Limit()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 3, windowSize: TimeSpan.FromMinutes(1));
+        var clientId = "client1";
+        var resource = "resource1";
+
+        // Act
+        var result1 = await rule.IsRequestAllowed(clientId, resource);
+        var result2 = await rule.IsRequestAllowed(clientId, resource);
+        var result3 = await rule.IsRequestAllowed(clientId, resource);
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeTrue();
+        result3.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Should_Deny_Requests_Exceeding_Limit()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 2, windowSize: TimeSpan.FromMinutes(1));
+        var clientId = "client1";
+        var resource = "resource1";
+
+        // Act
+        await rule.IsRequestAllowed(clientId, resource); // 1st request
+        await rule.IsRequestAllowed(clientId, resource); // 2nd request
+        var result = await rule.IsRequestAllowed(clientId, resource); // 3rd request
+
+        // Assert
+        result.Should().BeFalse(); // Should be denied
+    }
+
+    [Fact]
+    public async Task Should_Allow_Request_After_Window_Expires()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 2, windowSize: TimeSpan.FromSeconds(3));
+        var clientId = "client1";
+        var resource = "resource1";
+
+        // Act
+        await rule.IsRequestAllowed(clientId, resource); // 1st request
+        await rule.IsRequestAllowed(clientId, resource); // 2nd request
+        Task.Delay(3100).Wait(); // Wait more than window size
+        var result = await rule.IsRequestAllowed(clientId, resource); // Request after window expires
+
+        // Assert
+        result.Should().BeTrue(); // Should be allowed
+    }
+
+    [Fact]
+    public void RequestCountRule_Should_Handle_Negative_MaxRequests_Parameter()
+    {
+        // Arrange
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new RequestCountRule(maxRequests: -1, windowSize: TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public void RequestCountRule_Should_Handle_Negative_WindowSize_Parameter()
+    {
+        // Arrange
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new RequestCountRule(maxRequests: 1, windowSize: TimeSpan.FromSeconds(-1)));
+    }
+
+   [Fact]
+    public async Task IsRequestAllowed_Should_Handle_Empty_ClientId()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 1, windowSize: TimeSpan.FromSeconds(1)); // Negative maxRequests
+        var clientId = "";
+        var resource = "resource1";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(async () => await rule.IsRequestAllowed(clientId, resource));
+    }
+
+    [Fact]
+    public async Task IsRequestAllowed_Should_Handle_Null_ClientId()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 1, windowSize: TimeSpan.FromSeconds(1)); // Negative maxRequests
+        string clientId = null!;
+        var resource = "resource1";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await rule.IsRequestAllowed(clientId, resource));
+    }
+
+    [Fact]
+    public async Task IsRequestAllowed_Should_Handle_Empty_Resource()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 1, windowSize: TimeSpan.FromSeconds(1)); // Negative maxRequests
+        var clientId = "client1";
+        var resource = "";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(async () => await rule.IsRequestAllowed(clientId, resource));
+    }
+
+    [Fact]
+    public async Task IsRequestAllowed_Should_Handle_Null_Resource()
+    {
+        // Arrange
+        var rule = new RequestCountRule(maxRequests: 1, windowSize: TimeSpan.FromSeconds(1)); // Negative maxRequests
+        var clientId = "client1";
+        string resource = null!;
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await rule.IsRequestAllowed(clientId, resource));
+    }
+
+    #region Concurrency Tests
+
+    [Fact]
+    public async Task Should_Handle_Concurrency_Correctly()
+    {
+        // Arrange
+        const int maxConcurrency = 100;
+        var rule = new RequestCountRule(maxRequests: 10, windowSize: TimeSpan.FromSeconds(1));
+        var clientId = "concurrentClient";
+        var resource = "resource1";
+        var results = new ConcurrentBag<Task<bool>>();
+
+        // Act
+        var tasks = Enumerable.Range(0, maxConcurrency).Select(_ => Task.Run(async () =>
+        {
+            var isAllowed = await rule.IsRequestAllowed(clientId, resource);
+            results.Add(Task.FromResult(isAllowed));
+        }));
+
+        await Task.WhenAll(tasks);
+        // Await all tasks within the ConcurrentBag to get the boolean results
+        var completedResults = await Task.WhenAll(results);
+
+        // Assert
+        // Only 10 should be allowed; the rest should be denied.
+        var allowedCount = completedResults.Count(x => x);
+        var deniedCount = completedResults.Count(x => !x);
+
+        allowedCount.Should().Be(10);
+        deniedCount.Should().Be(maxConcurrency - 10);
+    }
+
+    #endregion
+
+    #region Performance Tests
+
+    [Fact]
+    public async void RequestCountRule_Should_Perform_Under_Heavy_Load()
+    {
+        // Arrange
+        const int maxRequests = 10000;
+        var rule = new RequestCountRule(maxRequests: maxRequests, windowSize: TimeSpan.FromSeconds(10));
+        var clientId = "performanceClient";
+        var resource = "resource1";
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        // Act
+        var tasks = Enumerable.Range(0, maxRequests).Select(_ => rule.IsRequestAllowed(clientId, resource));
+        await Task.WhenAll(tasks);
+
+        stopwatch.Stop();
+
+        // Assert
+        // Expect the operation to complete quickly, within a reasonable performance window. Need to revise this value as we add more code.
+        stopwatch.ElapsedMilliseconds.Should().BeLessOrEqualTo(1000);
+    }
+    #endregion
+}

--- a/RateLimiter.Tests/TimeSpanRuleTests.cs
+++ b/RateLimiter.Tests/TimeSpanRuleTests.cs
@@ -1,0 +1,63 @@
+﻿using FluentAssertions;
+using RateLimiter.Rules;
+
+namespace RateLimiter.Tests;
+
+public class TimeSpanRuleTests
+{
+    [Fact]
+    public async Task Allows_Requests_After_TimeSpan()
+    {
+        // Arrange
+        var rule = new TimeSpanRule(requiredTimeSpan: TimeSpan.FromSeconds(1));
+        var clientToken = "client1";
+        var resource = "resource1";
+
+        // Act
+        var result1 = await rule.IsRequestAllowed(clientToken, resource);
+        Thread.Sleep(1100); // Wait more than 1 second
+        var result2 = await rule.IsRequestAllowed(clientToken, resource);
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Denies_Requests_Within_TimeSpan()
+    {
+        // Arrange
+        var rule = new TimeSpanRule(requiredTimeSpan: TimeSpan.FromSeconds(2));
+        var clientToken = "client1";
+        var resource = "resource1";
+
+        // Act
+        await rule.IsRequestAllowed(clientToken, resource);
+        Thread.Sleep(1000); // Wait less than 2 seconds
+        var result = await rule.IsRequestAllowed(clientToken, resource);
+
+        // Assert
+        result.Should().BeFalse(); // Should be denied
+    }
+
+    #region Edge Case Tests
+
+    [Fact]
+    public async Task TimeSpanRule_Should_Handle_Zero_TimeSpan()
+    {
+        // Arrange
+        var rule = new TimeSpanRule(requiredTimeSpan: TimeSpan.Zero);
+        var clientToken = "edgeClient";
+        var resource = "resource1";
+
+        // Act
+        var result1 = await rule.IsRequestAllowed(clientToken, resource);
+        var result2 = await rule.IsRequestAllowed(clientToken, resource); // Immediate call
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeTrue(); // Should be allowed since the time span is zero
+    }
+
+    #endregion
+}

--- a/RateLimiter.sln
+++ b/RateLimiter.sln
@@ -1,16 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35027.167
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter", "RateLimiter\RateLimiter.csproj", "{36F4BDC6-D3DA-403A-8DB7-0C79F94B938F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RateLimiter", "RateLimiter\RateLimiter.csproj", "{36F4BDC6-D3DA-403A-8DB7-0C79F94B938F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter.Tests", "RateLimiter.Tests\RateLimiter.Tests.csproj", "{C4F9249B-010E-46BE-94B8-DD20D82F1E60}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RateLimiter.Tests", "RateLimiter.Tests\RateLimiter.Tests.csproj", "{C4F9249B-010E-46BE-94B8-DD20D82F1E60}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9B206889-9841-4B5E-B79B-D5B2610CCCFF}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApi", "TestApi\TestApi.csproj", "{743FBC43-6FE2-4365-8FE2-5D9C94504A6A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApi.IntegrationTests", "TestApi.IntegrationTests\TestApi.IntegrationTests.csproj", "{DC1AA1AA-1F0F-44FB-AEA2-ACE9C0FB7177}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +30,14 @@ Global
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4F9249B-010E-46BE-94B8-DD20D82F1E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{743FBC43-6FE2-4365-8FE2-5D9C94504A6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{743FBC43-6FE2-4365-8FE2-5D9C94504A6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{743FBC43-6FE2-4365-8FE2-5D9C94504A6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{743FBC43-6FE2-4365-8FE2-5D9C94504A6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC1AA1AA-1F0F-44FB-AEA2-ACE9C0FB7177}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC1AA1AA-1F0F-44FB-AEA2-ACE9C0FB7177}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC1AA1AA-1F0F-44FB-AEA2-ACE9C0FB7177}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC1AA1AA-1F0F-44FB-AEA2-ACE9C0FB7177}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RateLimiter.sln.DotSettings.user
+++ b/RateLimiter.sln.DotSettings.user
@@ -1,0 +1,11 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=2ac820d6_002Da695_002D4096_002Db87d_002D54a3f02fd165/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Should_Handle_Negative_WindowSize_Requests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::C4F9249B-010E-46BE-94B8-DD20D82F1E60::net8.0::RateLimiter.Tests.RequestCountRuleTests&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::C4F9249B-010E-46BE-94B8-DD20D82F1E60::net8.0::RateLimiter.Tests.TimeSpanRuleTests&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::C4F9249B-010E-46BE-94B8-DD20D82F1E60::net8.0::RateLimiter.Tests.RateLimiterTests.Should_Throw_Exception_For_Null_ClientId&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::C4F9249B-010E-46BE-94B8-DD20D82F1E60::net8.0::RateLimiter.Tests.RateLimiterTests&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::DC1AA1AA-1F0F-44FB-AEA2-ACE9C0FB7177::net8.0::TestApi.IntegrationTests.RateLimitingIntegrationTests&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::C4F9249B-010E-46BE-94B8-DD20D82F1E60::net8.0::RateLimiter.Tests.RateLimiterConfigTests.RateLimiterConfig_CacheExpirationInMinutes_ZeroOrNegative_ValidationFails&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/RateLimiter/DependencyInjection/RateLimiterExtensions.cs
+++ b/RateLimiter/DependencyInjection/RateLimiterExtensions.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using RateLimiter.Rules;
+
+namespace RateLimiter.DependencyInjection;
+
+public static class RateLimiterExtensions
+{
+    public static IServiceCollection AddRateLimiterServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddSingleton<IRateLimitRuleRepository, RateLimitRuleRepository>();
+        services.AddSingleton<IRateLimiter, RateLimiter>();
+
+        var apiConfigSection = configuration.GetSection(RateLimiterConfig.SectionName);
+        var apiConfig = new RateLimiterConfig();
+        apiConfigSection.Bind(apiConfig);
+        
+        new RateLimiterConfigValidator().ValidateAndThrow(apiConfig);
+        services.AddOptions<RateLimiterConfig>().Bind(apiConfigSection);
+        services
+            .TryAddSingleton<IValidateOptions<RateLimiterConfig>,
+                RateLimiterConfigValidator>();
+
+        return services;
+    }
+}

--- a/RateLimiter/IRateLimiter.cs
+++ b/RateLimiter/IRateLimiter.cs
@@ -1,0 +1,10 @@
+﻿using RateLimiter.Rules;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RateLimiter;
+
+public interface IRateLimiter
+{
+    Task<bool> IsRequestAllowed(string clientId, string resource);
+}

--- a/RateLimiter/RateLimiter.cs
+++ b/RateLimiter/RateLimiter.cs
@@ -1,0 +1,118 @@
+﻿using Ardalis.GuardClauses;
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using RateLimiter.Rules;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RateLimiter;
+
+public class RateLimiter(
+    IMemoryCache cache,
+    IRateLimitRuleRepository ruleRepository,
+    IOptions<RateLimiterConfig> rateLimiterConfig,
+    ILogger<RateLimiter> logger) : IRateLimiter
+{
+    private readonly IMemoryCache _cache = Guard.Against.Null(cache);
+    private readonly IRateLimitRuleRepository _ruleRepository = Guard.Against.Null(ruleRepository);
+    private readonly RateLimiterConfig _rateLimiterConfig = Guard.Against.Null(rateLimiterConfig.Value);
+    private readonly ILogger<RateLimiter> _logger = Guard.Against.Null(logger);
+
+    private readonly ConcurrentDictionary<string, HashSet<IRateLimitRule>> _resourceRules = new();
+
+    public async Task<bool> IsRequestAllowed(string clientId, string resource)
+    {
+        Guard.Against.NullOrEmpty(clientId);
+        Guard.Against.NullOrEmpty(resource);
+
+        var cachedRules = await GetCachedRules(clientId);
+        if (!cachedRules.Any())
+        {
+            cachedRules = await _ruleRepository.GetRulesByClientId(clientId);
+
+            if (!cachedRules.Any())
+            {
+                //TODO No rate limiting rules found for the client; we could either allow all requests or apply a default rule.
+                _logger.LogWarning($"No rate limiting rules found for client: {clientId}");
+                return false;
+            }
+
+            await ConfigureRules(clientId, cachedRules);
+        }
+
+        var key = BuildClientResourceKey(clientId, resource);
+        if (!_resourceRules.TryGetValue(key, out var rules))
+        {
+            //TODO No rate limiting rules found for the client; we could either allow all requests or apply a default rule.
+            return false;
+        }
+
+        var tasks = rules.Select(async rule => await rule.IsRequestAllowed(clientId, resource));
+        var results = await Task.WhenAll(tasks);
+        return results.All(result => result);
+    }
+
+    #region Private Method
+
+    /// <summary>
+    /// Configures rules from the database
+    /// </summary>
+    /// <param name="clientId"></param>
+    /// <param name="rules"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    private Task ConfigureRules(string clientId, IReadOnlyCollection<RateLimitRuleEntity> rules)
+    {
+        var cacheKey = BuildRateLimitCacheKey(clientId);
+        CacheRules(cacheKey, rules);
+
+        foreach (var ruleEntity in rules)
+        {
+            IRateLimitRule rule = ruleEntity.RuleType switch
+            {
+                RuleType.RequestCount => new RequestCountRule(ruleEntity.MaxRequests, ruleEntity.TimeSpan),
+                RuleType.TimeSpan => new TimeSpanRule(ruleEntity.RequiredTimeSpan),
+                _ => throw new ArgumentException("Unsupported rule type")
+            };
+
+            var key = BuildClientResourceKey(ruleEntity.ClientId, ruleEntity.Resource);
+            _resourceRules.AddOrUpdate(key, [rule], (_, existingRules) =>
+            {
+                existingRules.Add(rule);
+                return existingRules;
+            });
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task<IReadOnlyCollection<RateLimitRuleEntity>> GetCachedRules(string clientId)
+    {
+        Guard.Against.NullOrWhiteSpace(clientId);
+
+        _cache.TryGetValue(BuildRateLimitCacheKey(clientId), out List<RateLimitRuleEntity>? cachedRules);
+
+        return Task.FromResult((IReadOnlyCollection<RateLimitRuleEntity>)(cachedRules ?? []));
+    }
+
+    private string BuildRateLimitCacheKey(string clientId)
+    {
+        return $"RateLimitRules_{clientId}";
+    }
+
+    private string BuildClientResourceKey(string clientId, string resource)
+    {
+        return $"{clientId}-{resource}";
+    }
+
+    private void CacheRules(string cacheKey, IReadOnlyCollection<RateLimitRuleEntity> rules)
+    {
+        _cache.Set(cacheKey, rules, TimeSpan.FromMinutes(_rateLimiterConfig.CacheExpirationInMinutes));
+    }
+
+    #endregion
+}

--- a/RateLimiter/RateLimiter.csproj
+++ b/RateLimiter/RateLimiter.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Ardalis.GuardClauses" Version="4.6.0" />
+		<PackageReference Include="FluentValidation" Version="11.9.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+	</ItemGroup>
 </Project>  

--- a/RateLimiter/RateLimiterConfig.cs
+++ b/RateLimiter/RateLimiterConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace RateLimiter;
+
+public class RateLimiterConfig
+{
+    public const string SectionName = "RateLimiterConfig";
+
+    public int CacheExpirationInMinutes { get; set; }
+}

--- a/RateLimiter/RateLimiterConfigValidator.cs
+++ b/RateLimiter/RateLimiterConfigValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+
+namespace RateLimiter;
+
+public class RateLimiterConfigValidator: AbstractValidator<RateLimiterConfig>, IValidateOptions<RateLimiterConfig>
+{
+    public RateLimiterConfigValidator()
+    {
+        RuleFor(c => c.CacheExpirationInMinutes).GreaterThan(0);
+    }
+
+    public ValidateOptionsResult Validate(string? name, RateLimiterConfig options)
+    {
+        ValidationResult validationResult = this.Validate(options);
+        return !validationResult.IsValid
+            ? ValidateOptionsResult.Fail(
+                validationResult.Errors.Select<ValidationFailure, string>(
+                    (Func<ValidationFailure, string>)(x => x.ErrorMessage)))
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/RateLimiter/Rules/IRateLimitRule.cs
+++ b/RateLimiter/Rules/IRateLimitRule.cs
@@ -1,0 +1,8 @@
+﻿using System.Threading.Tasks;
+
+namespace RateLimiter.Rules;
+
+public interface IRateLimitRule
+{
+    Task<bool> IsRequestAllowed(string clientId, string resource);
+}

--- a/RateLimiter/Rules/IRateLimitRuleRepository.cs
+++ b/RateLimiter/Rules/IRateLimitRuleRepository.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RateLimiter.Rules;
+
+public interface IRateLimitRuleRepository
+{
+    Task<IReadOnlyCollection<RateLimitRuleEntity>> GetRulesByClientId(string clientId);
+}

--- a/RateLimiter/Rules/RateLimitRuleEntity.cs
+++ b/RateLimiter/Rules/RateLimitRuleEntity.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace RateLimiter.Rules;
+
+public class RateLimitRuleEntity
+{
+    public int Id { get; init; }
+    public required string ClientId { get; init; }
+    public required string Resource { get; init; }
+    public required RuleType RuleType { get; init; }
+    public int MaxRequests { get; init; }
+    public TimeSpan TimeSpan { get; init; }
+    public TimeSpan RequiredTimeSpan { get; init; }
+}

--- a/RateLimiter/Rules/RateLimitRuleRepository.cs
+++ b/RateLimiter/Rules/RateLimitRuleRepository.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RateLimiter.Rules
+{
+    public class RateLimitRuleRepository : IRateLimitRuleRepository
+    {
+        public Task<IReadOnlyCollection<RateLimitRuleEntity>> GetRulesByClientId(string clientId)
+        {
+            // Mock rules - replace with actual DB access logic
+            var rules = new List<RateLimitRuleEntity>
+            {
+                new()
+                {
+                    ClientId = clientId,
+                    Resource = "/api/resource/resourceA",
+                    RuleType = RuleType.RequestCount,
+                    MaxRequests = 5,
+                    TimeSpan = TimeSpan.FromMinutes(1)
+                },
+                new()
+                {
+                    ClientId = clientId,
+                    Resource = "/api/resource/resourceB",
+                    RuleType = RuleType.TimeSpan,
+                    RequiredTimeSpan = TimeSpan.FromSeconds(10)
+                }
+            };
+
+            return Task.FromResult(rules as IReadOnlyCollection<RateLimitRuleEntity>);
+        }
+    }
+}

--- a/RateLimiter/Rules/RequestCountRule.cs
+++ b/RateLimiter/Rules/RequestCountRule.cs
@@ -1,0 +1,52 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RateLimiter.Rules;
+
+/// <summary>
+/// Implements a rate limiting rule based on the maximum number of requests allowed
+/// within a specified time window for each client-resource pair.
+/// </summary>
+public class RequestCountRule(int maxRequests, TimeSpan windowSize) : IRateLimitRule
+{
+    private readonly int _maxRequests = Guard.Against.NegativeOrZero(maxRequests);
+    private readonly TimeSpan _windowSize = Guard.Against.NegativeOrZero(windowSize);
+
+    // Use a ConcurrentDictionary to store request timestamps for each client-resource pair
+    private readonly ConcurrentDictionary<string, List<DateTime>> _requestLogs = new();
+
+    /// <summary>
+    /// Determines whether a request is allowed based on the maximum number of requests
+    /// within a specified time window for a given client-resource pair.
+    /// </summary>
+    /// <param name="clientId">The unique identifier for the client making the request.</param>
+    /// <param name="resource">The resource being accessed by the client.</param>
+    public Task<bool> IsRequestAllowed(string clientId, string resource)
+    {
+        Guard.Against.NullOrWhiteSpace(clientId);
+        Guard.Against.NullOrWhiteSpace(resource);
+
+        var key = $"{clientId}:{resource}";
+        var utcNow = DateTime.UtcNow;
+
+        var requestTimestamps = _requestLogs.GetOrAdd(key, _ => []);
+
+        lock (requestTimestamps)
+        {
+            // Remove requests that are outside the sliding window
+            requestTimestamps.RemoveAll(timestamp => timestamp <= utcNow - _windowSize);
+
+            if (requestTimestamps.Count >= _maxRequests)
+            {
+                return Task.FromResult(false);
+            }
+
+            requestTimestamps.Add(utcNow);
+        }
+
+        return Task.FromResult(true);
+    }
+}

--- a/RateLimiter/Rules/RuleType.cs
+++ b/RateLimiter/Rules/RuleType.cs
@@ -1,0 +1,7 @@
+﻿namespace RateLimiter.Rules;
+
+public enum RuleType
+{
+    RequestCount,
+    TimeSpan
+}

--- a/RateLimiter/Rules/TimeSpanRule.cs
+++ b/RateLimiter/Rules/TimeSpanRule.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace RateLimiter.Rules;
+
+/// <summary>
+/// Implements a rate limiting rule based on a required time span between consecutive requests
+/// for a given client-resource pair.
+/// </summary>
+public class TimeSpanRule(TimeSpan requiredTimeSpan) : IRateLimitRule
+{
+    private readonly ConcurrentDictionary<string, DateTime> _lastRequestTime = new();
+
+    /// <summary>
+    /// Determines whether a request is allowed based on the required time span between 
+    /// consecutive requests for a specific client-resource pair.
+    /// 
+    /// The method checks the time of the last request made by the client for the specified 
+    /// resource. If the required time span has passed since the last request, it updates the 
+    /// last request time to the current timestamp and allows the request. If not, the request 
+    /// is denied.
+    /// </summary>
+    /// <param name="clientId">The unique identifier of the client making the request.</param>
+    /// <param name="resource">The resource being accessed by the client.</param>
+    public Task<bool> IsRequestAllowed(string clientId, string resource)
+    {
+        var key = $"{clientId}:{resource}";
+        var utcNow = DateTime.UtcNow;
+
+        if (!_lastRequestTime.TryGetValue(key, out var value))
+        {
+            _lastRequestTime[key] = utcNow;
+            return Task.FromResult(true);
+        }
+
+        var timeSinceLastRequest = utcNow - value;
+        if (timeSinceLastRequest >= requiredTimeSpan)
+        {
+            _lastRequestTime[key] = utcNow;
+            return Task.FromResult(true);
+        }
+
+        return Task.FromResult(false);
+    }
+}

--- a/TestApi.IntegrationTests/RateLimitingIntegrationTests.cs
+++ b/TestApi.IntegrationTests/RateLimitingIntegrationTests.cs
@@ -1,0 +1,135 @@
+﻿using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using RateLimiter.Rules;
+using TestApi.Common;
+
+namespace TestApi.IntegrationTests
+{
+    public class RateLimitingIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+        private const string ClientToken1 = "client-1";
+        private const string SlidingWindowToken = "sliding-window-test-token";
+
+        public RateLimitingIntegrationTests(WebApplicationFactory<Program> factory)
+        {
+            var mockRateLimitRuleRepository = new Mock<IRateLimitRuleRepository>();
+            mockRateLimitRuleRepository
+                .Setup(repo => repo.GetRulesByClientId(It.Is<string>(id => id == ClientToken1)))
+                .ReturnsAsync(new List<RateLimitRuleEntity>
+                {
+                    new RateLimitRuleEntity
+                    {
+                        ClientId = ClientToken1,
+                        Resource = Routes.ResourceA,
+                        RuleType = RuleType.RequestCount,
+                        MaxRequests = 5,
+                        TimeSpan = TimeSpan.FromSeconds(5)
+                    }
+                });
+            mockRateLimitRuleRepository
+                .Setup(repo => repo.GetRulesByClientId(It.Is<string>(id => id == SlidingWindowToken)))
+                .ReturnsAsync(new List<RateLimitRuleEntity>
+                {
+                    new()
+                    {
+                        ClientId = SlidingWindowToken,
+                        Resource = Routes.ResourceA,
+                        RuleType = RuleType.RequestCount,
+                        MaxRequests = 1,
+                        TimeSpan = TimeSpan.FromSeconds(1)
+                    }
+                });
+
+            _factory = factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IRateLimitRuleRepository));
+                    if (descriptor != null)
+                    {
+                        services.Remove(descriptor);
+                    }
+                    services.AddSingleton(mockRateLimitRuleRepository.Object);
+                    services.BuildServiceProvider();
+                });
+            });
+        }
+
+        [Fact]
+        public async Task RateLimiter_Should_Allow_Requests_Within_Limit()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.Add("Authorization", ClientToken1);
+
+            // Act
+            var response1 = await client.GetAsync(Routes.ResourceA);
+            var response2 = await client.GetAsync(Routes.ResourceA);
+
+            // Assert
+            response1.StatusCode.Should().Be(HttpStatusCode.OK);
+            response2.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task RateLimiter_Should_Enforce_Rate_Limit_And_Reject_Excess_Requests()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.Add("Authorization", ClientToken1);
+
+            // Act
+            for (int i = 0; i < 5; i++)
+            {
+                await client.GetAsync(Routes.ResourceA); // Assuming limit is 5 requests
+            }
+
+            var exceededResponse = await client.GetAsync(Routes.ResourceA);
+
+            // Assert
+            exceededResponse.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+            var content = await exceededResponse.Content.ReadAsStringAsync();
+            content.Should().Contain("Rate limit exceeded");
+        }
+
+        [Fact]
+        public async Task Should_Handle_Missing_Authorization_And_Resource()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.GetAsync(Routes.ResourceA);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var content = await response.Content.ReadAsStringAsync();
+            content.Should().Contain("Authorization token is missing or empty.");
+        }
+
+        [Fact]
+        public async Task Should_Apply_SlidingWindow_Rule_Correctly()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.Add("Authorization", SlidingWindowToken);
+
+            // Act
+            var firstResponse = await client.GetAsync(Routes.ResourceA);
+            await Task.Delay(1000); // Simulate sliding window effect
+            var secondResponse = await client.GetAsync(Routes.ResourceA);
+            await Task.Delay(1000); // Simulate window expiry
+            var thirdResponse = await client.GetAsync(Routes.ResourceA);
+
+            // Assert
+            firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            thirdResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+}

--- a/TestApi.IntegrationTests/TestApi.IntegrationTests.csproj
+++ b/TestApi.IntegrationTests/TestApi.IntegrationTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestApi\TestApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/TestApi/Common/Routes.cs
+++ b/TestApi/Common/Routes.cs
@@ -1,0 +1,9 @@
+﻿namespace TestApi.Common
+{
+    public static class Routes
+    {
+        public const string ResourceA = "/api/resource/resourceA";
+        public const string ResourceB = "/api/resource/resourceB";
+        public const string ResourceC = "/api/resource/resourceC";
+    }
+}

--- a/TestApi/Controllers/ResourceController.cs
+++ b/TestApi/Controllers/ResourceController.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using TestApi.Common;
+
+namespace TestApi.Controllers
+{
+    [ApiController]
+    public class ResourceController : ControllerBase
+    {
+        [HttpGet(Routes.ResourceA)]
+        public IActionResult GetResourceA()
+        {
+            return Ok("Accessed Resource A");
+        }
+
+        [HttpGet(Routes.ResourceB)]
+        public IActionResult GetResourceB()
+        {
+            return Ok("Accessed Resource B");
+        }
+
+        [HttpGet(Routes.ResourceC)]
+        public IActionResult GetResourceC()
+        {
+            return Ok("Accessed Resource C");
+        }
+    }
+}

--- a/TestApi/Middleware/RateLimitingMiddleware.cs
+++ b/TestApi/Middleware/RateLimitingMiddleware.cs
@@ -1,0 +1,65 @@
+﻿using Ardalis.GuardClauses;
+using RateLimiter;
+
+namespace TestApi.Middleware
+{
+    public class RateLimitingMiddleware(
+       IRateLimiter rateLimiter,
+        ILogger<RateLimitingMiddleware> logger): IMiddleware
+    {
+        private readonly IRateLimiter _rateLimiter = Guard.Against.Null(rateLimiter);
+        private readonly ILogger<RateLimitingMiddleware> _logger = Guard.Against.Null(logger);
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            Guard.Against.Null(context);
+            Guard.Against.Null(next);
+
+            // Extract client token and resource path from the request
+            var clientToken = context.Request.Headers["Authorization"];
+            var resource = context.Request.Path.Value;
+
+            if (string.IsNullOrEmpty(clientToken))
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Authorization token is missing or empty.");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(resource))
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Resource identifier is missing or empty.");
+                return;
+            }
+
+            var clientId = GetClientId(clientToken!);
+            try
+            {
+                if (!await _rateLimiter.IsRequestAllowed(clientId, resource))
+                {
+                    context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                    await context.Response.WriteAsync("Rate limit exceeded. Please try again later.");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while applying rate limiting");
+                // Handle error gracefully, possibly allow the request or return a different status
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                await context.Response.WriteAsync("An error occurred while processing your request.");
+                return;
+            }
+
+            // Call the next middleware in the pipeline
+            await next(context);
+        }
+
+        private string GetClientId(string clientToken)
+        {
+            //TODO pull ClientId from the authorization token
+            return clientToken;
+        }
+    }
+}

--- a/TestApi/Program.cs
+++ b/TestApi/Program.cs
@@ -1,0 +1,45 @@
+using RateLimiter.DependencyInjection;
+using TestApi.Middleware;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMemoryCache();
+builder.Services.AddLogging();
+
+builder.Services.AddRateLimiterServices(builder.Configuration);
+builder.Services.AddTransient<RateLimitingMiddleware>();
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseMiddleware<RateLimitingMiddleware>();
+app.UseHttpsRedirection();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapControllers();
+});
+
+app.Run();
+
+namespace TestApi
+{
+    public partial class Program
+    {
+    }
+}

--- a/TestApi/Properties/launchSettings.json
+++ b/TestApi/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:11938",
+      "sslPort": 44372
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5172",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7095;http://localhost:5172",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/TestApi/TestApi.csproj
+++ b/TestApi/TestApi.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestApi/TestApi.csproj.user
+++ b/TestApi/TestApi.csproj.user
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ActiveDebugProfile>https</ActiveDebugProfile>
+    <Controller_SelectedScaffolderID>MvcControllerEmptyScaffolder</Controller_SelectedScaffolderID>
+    <Controller_SelectedScaffolderCategoryPath>root/Common/MVC/Controller</Controller_SelectedScaffolderCategoryPath>
+  </PropertyGroup>
+</Project>

--- a/TestApi/TestApi.http
+++ b/TestApi/TestApi.http
@@ -1,0 +1,6 @@
+@TestApi_HostAddress = http://localhost:5172
+
+GET {{TestApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/TestApi/appsettings.Development.json
+++ b/TestApi/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "RateLimiterConfig": {
+    "CacheExpirationInMinutes": 10
+  }
+}

--- a/TestApi/appsettings.json
+++ b/TestApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Added a basic version of the RateLimiter implementation, designed for scenarios where APIs need to dynamically manage request limits based on configurable rules stored in a database.

Project Structure

- Rate Limiter:
  - Implemented two new rate-limiting rules:
    - `RequestCountRule`: Utilizes a sliding window technique to limit requests based on count within a specified timeframe.
    - `TimeSpanRule`: Allows requests to be processed only after a specified time interval has passed.
  -   Integrated Ardalis Guard Clauses for parameter validation.
  - Applied `FluentValidation` for robust validation logic.
  - Leveraged `Dependency Injection (DI)` to enhance testability and maintainability.

- Test API:
  - Developed a Test API to validate the RateLimiter functionality.
  - Added a `middleware` to apply the RateLimiter to incoming requests.

- RateLimiter.Tests:
  - Includes comprehensive unit tests for the RateLimiter, RequestCountRule, and TimeSpanRule.
  - Used `Moq` and `FluentAssertions` for unit testing and assertion checks.

 - TestApi.IntegrationTests:
   - Contains `integration tests` for the Test API to verify the end-to-end behavior of the RateLimiter.