### PR TITLE
Daniel Slocum

### DIFF
--- a/RateLimiter.Tests/Middleware/RateLimiterMiddlewareTests.cs
+++ b/RateLimiter.Tests/Middleware/RateLimiterMiddlewareTests.cs
@@ -1,0 +1,74 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+using RateLimiter.Middleware;
+using RateLimiter.Services;
+
+namespace RateLimiter.Tests.Middleware;
+
+public class RateLimiterMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_ShouldReturn401_WhenTokenIsMissing()
+    {
+        // Arrange
+        var rateLimiterMock = new Mock<IRateLimiterService>();
+        var middleware = new RateLimiterMiddleware(async (context) => { await Task.CompletedTask; }, rateLimiterMock.Object);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/test/endpoint";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldReturn429_WhenRateLimitIsExceeded()
+    {
+        // Arrange
+        var rateLimiterMock = new Mock<IRateLimiterService>();
+        rateLimiterMock
+            .Setup(r => r.IsRequestAllowed(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(false);
+
+        var middleware = new RateLimiterMiddleware(async (context) => { await Task.CompletedTask; }, rateLimiterMock.Object);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/test/endpoint";
+        context.Request.Headers["X-Client-Token"] = "client-token";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldCallNextMiddleware_WhenRequestIsAllowed()
+    {
+        // Arrange
+        var rateLimiterMock = new Mock<IRateLimiterService>();
+        rateLimiterMock
+            .Setup(r => r.IsRequestAllowed(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(true);
+
+        var nextMiddlewareCalled = false;
+        var middleware = new RateLimiterMiddleware(async (context) => { nextMiddlewareCalled = true; await Task.CompletedTask; }, rateLimiterMock.Object);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/test/endpoint";
+        context.Request.Headers["X-Client-Token"] = "client-token";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.True(nextMiddlewareCalled);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+}

--- a/RateLimiter.Tests/RateLimiter.Tests.csproj
+++ b/RateLimiter.Tests/RateLimiter.Tests.csproj
@@ -8,8 +8,15 @@
     <ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>  

--- a/RateLimiter.Tests/Rules/RequestPerTimeSpanRuleTests.cs
+++ b/RateLimiter.Tests/Rules/RequestPerTimeSpanRuleTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using RateLimiter.Rules;
+
+namespace RateLimiter.Tests.Rules;
+
+public class RequestPerTimeSpanRuleTests
+{
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenRequestLogsAreEmpty()
+    {
+        // Arrange
+        var rule = new RequestPerTimeSpanRule(5, TimeSpan.FromMinutes(1));
+        var requestLogs = new List<DateTime>();
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenRequestCountIsBelowLimit()
+    {
+        // Arrange
+        var rule = new RequestPerTimeSpanRule(5, TimeSpan.FromMinutes(1));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-10),
+            DateTime.UtcNow.AddSeconds(-20)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnFalse_WhenRequestCountExceedsLimit()
+    {
+        // Arrange
+        var rule = new RequestPerTimeSpanRule(3, TimeSpan.FromMinutes(1));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-10),
+            DateTime.UtcNow.AddSeconds(-20),
+            DateTime.UtcNow.AddSeconds(-30)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenRequestCountIsBelowLimitWithOutdatedRequests()
+    {
+        // Arrange
+        var rule = new RequestPerTimeSpanRule(3, TimeSpan.FromSeconds(15));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-20),
+            DateTime.UtcNow.AddSeconds(-10),
+            DateTime.UtcNow.AddSeconds(-5)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(2, requestLogs.Count);
+    }
+}

--- a/RateLimiter.Tests/Rules/TimeSpanSinceLastRequestRuleTests.cs
+++ b/RateLimiter.Tests/Rules/TimeSpanSinceLastRequestRuleTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using RateLimiter.Rules;
+
+namespace RateLimiter.Tests.Rules;
+
+public class TimeSpanSinceLastRequestRuleTests
+{
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenRequestLogsAreEmpty()
+    {
+        // Arrange
+        var rule = new TimeSpanSinceLastRequestRule(TimeSpan.FromSeconds(10));
+        var requestLogs = new List<DateTime>();
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenTimeSinceLastRequestExceedsLimit()
+    {
+        // Arrange
+        var rule = new TimeSpanSinceLastRequestRule(TimeSpan.FromSeconds(10));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-15)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnFalse_WhenTimeSinceLastRequestIsBelowLimit()
+    {
+        // Arrange
+        var rule = new TimeSpanSinceLastRequestRule(TimeSpan.FromSeconds(10));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-5)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenLastRequestExceedsLimitWithMultipleOlderRequestsInLogs()
+    {
+        // Arrange
+        var rule = new TimeSpanSinceLastRequestRule(TimeSpan.FromSeconds(10));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-30),
+            DateTime.UtcNow.AddSeconds(-25),
+            DateTime.UtcNow.AddSeconds(-20)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnFalse_WhenLastRequestIsBelowLimitWithMultipleRequestsInLogs()
+    {
+        // Arrange
+        var rule = new TimeSpanSinceLastRequestRule(TimeSpan.FromSeconds(10));
+        var requestLogs = new List<DateTime>
+        {
+            DateTime.UtcNow.AddSeconds(-20),
+            DateTime.UtcNow.AddSeconds(-15),
+            DateTime.UtcNow.AddSeconds(-5)
+        };
+        var timeOfRequest = DateTime.UtcNow;
+
+        // Act
+        bool result = rule.IsRequestAllowed(requestLogs, timeOfRequest);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/RateLimiter.Tests/Services/RateLimiterServiceTests.cs
+++ b/RateLimiter.Tests/Services/RateLimiterServiceTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using RateLimiter.Rules;
+using RateLimiter.Services;
+
+namespace RateLimiter.Tests.Services;
+
+public class RateLimiterServiceTests
+{
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenNoRulesExist()
+    {
+        // Arrange
+        var rules = new Dictionary<string, List<IRateLimitRule>>();
+        var service = new RateLimiterService(rules);
+
+        // Act
+        bool result = service.IsRequestAllowed("/test/endpoint", "client-token");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenNoRulesExistForEndpoint()
+    {
+        // Arrange
+        var rules = new Dictionary<string, List<IRateLimitRule>>
+        {
+            {
+                "/test/endpoint",
+                new List<IRateLimitRule>
+                {
+                    new RequestPerTimeSpanRule(1, TimeSpan.FromMinutes(1))
+                }
+            }
+        };
+        var service = new RateLimiterService(rules);
+
+        // Act
+        bool result = service.IsRequestAllowed("/test/endpoint-one", "client-token");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnFalse_WhenRuleBlocksRequest()
+    {
+        // Arrange
+        var rules = new Dictionary<string, List<IRateLimitRule>>
+        {
+            {
+                "/test/endpoint",
+                new List<IRateLimitRule>
+                {
+                    new RequestPerTimeSpanRule(1, TimeSpan.FromMinutes(1))
+                }
+            }
+        };
+        var service = new RateLimiterService(rules);
+
+        // Act
+        bool firstRequest = service.IsRequestAllowed("/test/endpoint", "client-token");
+        bool secondRequest = service.IsRequestAllowed("/test/endpoint", "client-token");
+
+        // Assert
+        Assert.True(firstRequest);
+        Assert.False(secondRequest);
+    }
+
+    [Fact]
+    public void IsRequestAllowed_ShouldReturnTrue_WhenRequestsAreFromDifferentClients()
+    {
+        // Arrange
+        var rules = new Dictionary<string, List<IRateLimitRule>>
+        {
+            {
+                "/test/endpoint",
+                new List<IRateLimitRule>
+                {
+                    new RequestPerTimeSpanRule(1, TimeSpan.FromMinutes(1))
+                }
+            }
+        };
+        var service = new RateLimiterService(rules);
+
+        // Act
+        bool token1Request = service.IsRequestAllowed("/test/endpoint", "client-token-1");
+        bool token2Request = service.IsRequestAllowed("/test/endpoint", "client-token-2");
+
+        // Assert
+        Assert.True(token1Request);
+        Assert.True(token2Request);
+    }
+}

--- a/RateLimiter/Middleware/RateLimiterExtensions.cs
+++ b/RateLimiter/Middleware/RateLimiterExtensions.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using RateLimiter.Models;
+using RateLimiter.Services;
+
+namespace RateLimiter.Middleware;
+
+/// <summary>
+/// Provides extension methods for configuring and using the rate limiter middleware.
+/// </summary>
+public static class RateLimiterExtensions
+{
+    /// <summary>
+    /// Adds the rate limiter service to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection to add the rate limiter to.</param>
+    /// <param name="options">A configuration action to set up rate limiter options.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddRateLimiter(this IServiceCollection services, Action<RateLimiterOptions> options)
+    {
+        RateLimiterOptions rateLimiterOptions = new();
+        options(rateLimiterOptions);
+
+        services.AddSingleton<IRateLimiterService>(provider => new RateLimiterService(rateLimiterOptions.Rules));
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the rate limiter middleware to the application's request pipeline.
+    /// </summary>
+    /// <param name="app">The application builder to configure the middleware.</param>
+    /// <returns>The updated application builder.</returns>
+    public static IApplicationBuilder UseRateLimiter(this IApplicationBuilder app)
+    {
+        var options = app.ApplicationServices.GetRequiredService<RateLimiterOptions>();
+        var rateLimiter = app.ApplicationServices.GetRequiredService<IRateLimiterService>();
+
+        return app.UseMiddleware<RateLimiterMiddleware>(rateLimiter, options);
+    }
+}

--- a/RateLimiter/Middleware/RateLimiterMiddleware.cs
+++ b/RateLimiter/Middleware/RateLimiterMiddleware.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using RateLimiter.Services;
+
+namespace RateLimiter.Middleware;
+
+/// <summary>
+/// Middleware for rate limiting requests based on predefined rules.
+/// </summary>
+public class RateLimiterMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IRateLimiterService _rateLimiter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="rateLimiter">The rate limiter service.</param>
+    public RateLimiterMiddleware(RequestDelegate next, IRateLimiterService rateLimiter)
+    {
+        _next = next;
+        _rateLimiter = rateLimiter;
+    }
+
+    /// <summary>
+    /// Invokes the middleware to check the rate limit for the current request.
+    /// </summary>
+    /// <param name="context">The HTTP context of the current request.</param>
+    /// <returns>A task that represents the completion of request processing.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        string resource = context.Request.Path.ToString();
+        string token = context.Request.Headers["X-Client-Token"].FirstOrDefault() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(token))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+        else if (!_rateLimiter.IsRequestAllowed(resource, token))
+        {
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            await context.Response.WriteAsync("Request limit exceeded.");
+            return;
+        }
+
+        await _next(context);
+    }
+}

--- a/RateLimiter/Models/RateLimiterOptions.cs
+++ b/RateLimiter/Models/RateLimiterOptions.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using RateLimiter.Rules;
+
+namespace RateLimiter.Models;
+
+/// <summary>
+/// Represents the configuration options for the rate limiter.
+/// </summary>
+public class RateLimiterOptions
+{
+    /// <summary>
+    /// Gets or sets the rate limit rules for each endpoint.
+    /// </summary>
+    /// <remarks>
+    /// The dictionary key represents the endpoint, and the value is a list of rate limit rules that apply to that endpoint.
+    /// </remarks>
+    public Dictionary<string, List<IRateLimitRule>> Rules { get; set; } = new();
+}

--- a/RateLimiter/RateLimiter.csproj
+++ b/RateLimiter/RateLimiter.csproj
@@ -4,4 +4,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+  </ItemGroup>
 </Project>  

--- a/RateLimiter/Rules/IRateLimitRule.cs
+++ b/RateLimiter/Rules/IRateLimitRule.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Rules;
+
+/// <summary>
+/// Defines a rule for rate limiting requests.
+/// </summary>
+public interface IRateLimitRule
+{
+    /// <summary>
+    /// Determines whether a request is allowed based on the provided timestamps and request time.
+    /// </summary>
+    /// <param name="requestLogs">A list of timestamps representing previous requests.</param>
+    /// <param name="timeOfRequest">The time of the current request.</param>
+    /// <returns>True if the request is allowed; otherwise, false.</returns>
+    bool IsRequestAllowed(List<DateTime> requestLogs, DateTime timeOfRequest);
+}

--- a/RateLimiter/Rules/RequestPerTimeSpanRule.cs
+++ b/RateLimiter/Rules/RequestPerTimeSpanRule.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace RateLimiter.Rules;
+
+/// <summary>
+/// A rule that limits the number of requests within a specified time window.
+/// </summary>
+public class RequestPerTimeSpanRule : IRateLimitRule
+{
+    private readonly int _requestLimit;
+    private readonly TimeSpan _window;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestPerTimeSpanRule"/> class.
+    /// </summary>
+    /// <param name="requestLimit">The maximum number of requests allowed within the time window.</param>
+    /// <param name="window">The time window for the rate limit.</param>
+    public RequestPerTimeSpanRule(int requestLimit, TimeSpan window)
+    {
+        _requestLimit = requestLimit;
+        _window = window;
+    }
+
+    /// <summary>
+    /// Determines whether a request is allowed based on the provided timestamps and request time.
+    /// </summary>
+    /// <param name="requestLogs">A list of timestamps representing previous requests.</param>
+    /// <param name="timeOfRequest">The time of the current request.</param>
+    /// <returns>True if the request is allowed; otherwise, false.</returns>
+    public bool IsRequestAllowed(List<DateTime> requestLogs, DateTime timeOfRequest)
+    {
+        if (requestLogs == null || requestLogs.Count == 0)
+        {
+            return true;
+        }
+
+        lock (requestLogs)
+        {   
+            requestLogs.RemoveAll(timestamp => timestamp < timeOfRequest - _window);
+
+            return requestLogs.Count < _requestLimit;
+        }
+    }
+}

--- a/RateLimiter/Rules/TimeSpanSinceLastRequestRule.cs
+++ b/RateLimiter/Rules/TimeSpanSinceLastRequestRule.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RateLimiter.Rules;
+
+/// <summary>
+/// A rule that enforces a minimum time span between consecutive requests.
+/// </summary>
+public class TimeSpanSinceLastRequestRule : IRateLimitRule
+{
+    private readonly TimeSpan _timeBetweenRequests;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeSpanSinceLastRequestRule"/> class.
+    /// </summary>
+    /// <param name="timeBetweenRequests">The minimum time span required between consecutive requests.</param>
+    public TimeSpanSinceLastRequestRule(TimeSpan timeBetweenRequests)
+    {
+        _timeBetweenRequests = timeBetweenRequests;
+    }
+
+    /// <summary>
+    /// Determines whether a request is allowed based on the provided timestamps and request time.
+    /// </summary>
+    /// <param name="requestLogs">A list of timestamps representing previous requests.</param>
+    /// <param name="timeOfRequest">The time of the current request.</param>
+    /// <returns>True if the request is allowed; otherwise, false.</returns>
+    public bool IsRequestAllowed(List<DateTime> requestLogs, DateTime timeOfRequest)
+    {
+        if (requestLogs == null || requestLogs.Count == 0)
+        {
+            return true;
+        }
+
+        DateTime lastRequest = requestLogs.Max();
+
+        return timeOfRequest - lastRequest > _timeBetweenRequests;
+    }
+}

--- a/RateLimiter/Services/IRateLimiterService.cs
+++ b/RateLimiter/Services/IRateLimiterService.cs
@@ -1,0 +1,12 @@
+namespace RateLimiter.Services;
+
+public interface IRateLimiterService
+{
+    /// <summary>
+    /// Determines whether a request is allowed based on the endpoint and token.
+    /// </summary>
+    /// <param name="endpoint">The endpoint being accessed.</param>
+    /// <param name="token">The token representing the client making the request.</param>
+    /// <returns>True if the request is allowed; otherwise, false.</returns>
+    bool IsRequestAllowed(string endpoint, string token);
+}

--- a/RateLimiter/Services/RateLimiterService.cs
+++ b/RateLimiter/Services/RateLimiterService.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using RateLimiter.Rules;
+
+namespace RateLimiter.Services;
+
+/// <summary>
+/// Service for rate limiting requests based on predefined rules.
+/// </summary>
+public class RateLimiterService : IRateLimiterService
+{
+    private readonly ConcurrentDictionary<string, List<DateTime>> _requestLogs = new();
+    private readonly Dictionary<string, List<IRateLimitRule>> _rules = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterService"/> class.
+    /// </summary>
+    /// <param name="rules">A dictionary where the key is the endpoint, and the value is a list of rate limit rules that apply to that endpoint.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="rules"/> parameter is null.</exception>
+    public RateLimiterService(Dictionary<string, List<IRateLimitRule>> rules)
+    {
+        _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+    }
+
+    /// <summary>
+    /// Determines whether a request is allowed based on the endpoint and token.
+    /// </summary>
+    /// <param name="endpoint">The endpoint being accessed.</param>
+    /// <param name="token">The token representing the client making the request.</param>
+    /// <returns>True if the request is allowed; otherwise, false.</returns>
+    public bool IsRequestAllowed(string endpoint, string token)
+    {
+        List<IRateLimitRule> rules = new();
+        if (!_rules.TryGetValue(endpoint, out rules))
+        {
+            return true;
+        }
+
+        if (rules.Count == 0)
+        {
+            return true;
+        }
+
+        string key = $"{endpoint}:{token}";
+        DateTime now = DateTime.UtcNow;
+        List<DateTime> logs = _requestLogs.GetOrAdd(key, _ => new List<DateTime>());
+
+        bool isAllowed;
+        lock (logs)
+        {
+            isAllowed = rules.All(rule => rule.IsRequestAllowed(logs, now));
+            if (isAllowed)
+            {
+                logs.Add(now);
+            }
+        }
+
+        return isAllowed;
+    }
+}


### PR DESCRIPTION
### Adding and Using Rate Limiter Middleware
You can add the rate limiter and configure the rules through the rate limiter options.
```
// Add services to the container
builder.Services.AddRateLimiter(options =>
{
    // Configure rate limiter rules
    options.Rules.Add("/api/resource", new List<IRateLimitRule>
    {
        new RequestPerTimeSpanRule(5, TimeSpan.FromMinutes(1)), // Max 5 requests per minute
        new TimeSpanSinceLastRequestRule(TimeSpan.FromSeconds(10)) // At least 10 seconds between requests
    });
});
```

Once added, you can include the middleware in the request pipeline.
```
app.UseRateLimiter();
```

### Rule Registration
Rules are tied to an endpoint, for example `/api/resource`, with support for multiple rules. You can include as many endpoints as desired. If a rule is not included, it is considered open and the request will be allowed. Current rule types supported are:
* Maximum number of requests for X time span
* Minimum of X time span between requests

The service is designed to run any new rules that are created and registered.